### PR TITLE
Migrate dead PID cleanup cron to Artisan command

### DIFF
--- a/laravel/app/Console/Commands/Process/CleanupDeadPids.php
+++ b/laravel/app/Console/Commands/Process/CleanupDeadPids.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands\Process;
+
+use App\Models\InstanceProcess;
+use Illuminate\Console\Command;
+
+class CleanupDeadPids extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'process:cleanup-dead-pids';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Cleans up dead process IDs from the database.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $instance_processes = InstanceProcess::all(['id', 'process_id']);
+
+        $this->info('Checking '.$instance_processes->count().' PIDs from the database...');
+
+        foreach ($instance_processes as $process) {
+            if (file_exists("/proc/$process->process_id") and (strpos(file_get_contents("/proc/$process->process_id/cmdline"), 'instance:start-teamspeak-bot') !== false)) {
+                $this->info("PID $process->process_id is still active. Skipping.");
+                continue;
+            }
+
+            if ($process->delete()) {
+                $this->warn("PID $process->process_id is not active anymore. Successfully removed it from the database.");
+            } else {
+                $this->error("PID $process->process_id is not active anymore. Failed to remove it from the database.");
+            }
+        }
+    }
+}

--- a/laravel/app/Console/Kernel.php
+++ b/laravel/app/Console/Kernel.php
@@ -44,15 +44,7 @@ class Kernel extends ConsoleKernel
 
         // INSTANCES: Cleanup dead processes
         $schedule->call(function () {
-            foreach (InstanceProcess::all(['id', 'process_id']) as $process) {
-                if (file_exists("/proc/$process->process_id")) {
-                    continue;
-                }
-
-                Log::info("Cleaning up dead PID $process->process_id from database...");
-
-                $process->delete();
-            }
+            Process::start('php '.base_path().'/artisan process:cleanup-dead-pids');
         })->environments(['staging', 'production'])->name('instances:cleanup-dead-processes')->everyMinute();
 
         // INSTANCES: Autostart


### PR DESCRIPTION
The scheduling still takes care about the regular cleanup, but as administrator you will now also be able to execute the cleanup task manually using the Artisan command.

An additional check for the PID status has been added to ensure, that the existing PID is the expected PID and not any other, which randomly got the same PID.