### PR TITLE
Add single "Hostbanner URL" for different redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Be a [stargazer](https://github.com/Sebbo94BY/teamspeak-dynamic-banner/stargazer
         * Non-Random: Every client, which requests the banner, will always see the same template as all other clients.
         * Random: Every client, which requests the banner, gets a random, maybe different template shown.
 * Add and configure one or more templates for each banner
+    * Configure (different) URL redirects for each banner (e.g. one banner redirects to your homepage, the other to your social media account)
     * Over 140 standard variables (e.g. current time, count of online clients, client nickname, etc.)
     * Use your preferred TrueType Font (TTF)
     * Set the font size for your texts

--- a/laravel/app/Http/Controllers/API/v1/BannerController.php
+++ b/laravel/app/Http/Controllers/API/v1/BannerController.php
@@ -8,44 +8,82 @@ use App\Models\Banner;
 use App\Models\BannerTemplate;
 use Carbon\Carbon;
 use Exception;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
 
 class BannerController extends Controller
 {
+    /**
+     * Class properties
+     */
+    private Banner $banner;
+
+    private Collection|BannerTemplate $banner_templates;
+
+    private ?BannerTemplate $selected_banner_template;
+
+    private ?string $response_text = null;
+
+    private int $response_code;
+
+    /**
+     * The class constructor
+     */
+    public function __construct(Request $request)
+    {
+        try {
+            $this->banner = Banner::findOrFail(base_convert($request->banner_id, 35, 10));
+        } catch (ModelNotFoundException) {
+            $this->response_text = 'Invalid Banner ID in the URL.';
+            $this->response_code = 404;
+
+            return;
+        }
+
+        $this->banner_templates = BannerTemplate::where(['banner_id' => $this->banner->id, 'enabled' => true])->get();
+
+        if ($this->banner_templates->count() == 0) {
+            $this->response_text = 'The banner does either not have any configured templates or all of them are disabled.';
+            $this->response_code = 401;
+
+            return;
+        }
+
+        if ($request->has('banner_template_id')) {
+            $this->selected_banner_template = $this->banner_templates->where('id', '=', $request->banner_template_id)->first();
+
+            if (is_null($this->selected_banner_template)) {
+                $this->response_text = 'Invalid Banner Template ID in the URL.';
+                $this->response_code = 404;
+
+                return;
+            }
+        } elseif ($this->banner->random_rotation) {
+            $this->selected_banner_template = $this->banner_templates->random(1)->first();
+        } else {
+            $current_minute = Carbon::now()->format('i');
+            $display_duration_per_template = intval(60 / $this->banner_templates->count());
+            $this->selected_banner_template = $this->banner_templates[abs(intval(ceil($current_minute / $display_duration_per_template)) - 1)];
+        }
+
+        if (count($this->selected_banner_template->configurations) == 0) {
+            $this->response_text = 'The template does not have any configurations. This seems wrong.';
+            $this->response_code = 500;
+
+            return;
+        }
+    }
+
     /**
      * Return the rendered template.
      */
     public function get_rendered_template(Request $request)
     {
-        try {
-            $banner = Banner::findOrFail(base_convert($request->banner_id, 35, 10));
-        } catch (ModelNotFoundException) {
-            return response('Invalid Banner ID in the URL.', 404);
+        if (! is_null($this->response_text)) {
+            return response($this->response_text, $this->response_code);
         }
-
-        $all_enabled_banner_templates = BannerTemplate::where(['banner_id' => $banner->id, 'enabled' => true])->get();
-
-        if ($all_enabled_banner_templates->count() == 0) {
-            return response('The banner does either not have any configured templates or all of them are disabled.', 401);
-        }
-
-        if ($banner->random_rotation) {
-            $banner_template = $all_enabled_banner_templates->random(1)->first();
-        } else {
-            $current_minute = Carbon::now()->format('i');
-            $display_duration_per_template = intval(60 / $all_enabled_banner_templates->count());
-            $banner_template = $all_enabled_banner_templates[abs(intval(ceil($current_minute / $display_duration_per_template)) - 1)];
-        }
-
-        $banner_configurations = $banner_template->configurations;
-
-        if (count($banner_configurations) == 0) {
-            return response('The template does not have any configurations. This seems wrong.', 500);
-        }
-
-        // Return the generated image to the client
-        $draw_text_on_template_helper = new DrawTextOnTemplateController();
 
         // Set headers to e. g. avoid caching
         $current_rfc7231_datetime = Carbon::now()->subSeconds(5)->toRfc7231String();
@@ -55,10 +93,29 @@ class BannerController extends Controller
         header('Last-Modified: '.$current_rfc7231_datetime);
         header('Content-Type: image/jpeg');
 
+        // Return the generated image to the client
+        $draw_text_on_template_helper = new DrawTextOnTemplateController();
+
         try {
-            $draw_text_on_template_helper->draw_text_to_image($banner_template, false, true, $request->ip());
+            $draw_text_on_template_helper->draw_text_to_image($this->selected_banner_template, false, true, $request->ip());
         } catch (Exception $exception) {
             return response($exception->getMessage(), 500);
         }
+    }
+
+    /**
+     * Redirect to the templates specified URL, if any is specified.
+     */
+    public function redirect_url()
+    {
+        if (! is_null($this->response_text)) {
+            return response($this->response_text, $this->response_code);
+        }
+
+        if (is_null($this->selected_banner_template->redirect_url)) {
+            return Redirect::route('api.banner', ['banner_id' => base_convert($this->banner->id, 10, 35)]);
+        }
+
+        return Redirect::to($this->selected_banner_template->redirect_url, 302);
     }
 }

--- a/laravel/app/Http/Controllers/BannerConfigurationController.php
+++ b/laravel/app/Http/Controllers/BannerConfigurationController.php
@@ -67,6 +67,18 @@ class BannerConfigurationController extends Controller
                 ]);
         }
 
+        $banner_template->redirect_url = $request->redirect_url;
+
+        if (! $banner_template->save()) {
+            return Redirect::route('banner.template.configuration.edit', ['banner_id' => $banner_template->banner_id, 'template_id' => $banner_template->template_id])
+                ->withInput($request->all())
+                ->with([
+                    'banner_template' => $banner_template,
+                    'error' => 'banner-template-redirect-url-error',
+                    'message' => 'Failed to update the redirect URL for this banner template in the database. Please try again.',
+                ]);
+        }
+
         $banner_configurations = [];
 
         for ($i = 0; $i < count($request->font_color_in_hexadecimal); $i++) {

--- a/laravel/app/Http/Requests/BannerConfigurationUpsertRequest.php
+++ b/laravel/app/Http/Requests/BannerConfigurationUpsertRequest.php
@@ -17,6 +17,7 @@ class BannerConfigurationUpsertRequest extends FormRequest
         $banner_template = BannerTemplate::findOrFail($this->banner_template_id);
 
         return [
+            'redirect_url' => ['nullable', 'url'],
             'banner_configuration_id.*' => ['sometimes', 'integer', 'exists:App\Models\BannerConfiguration,id'],
             'banner_template_id' => ['sometimes', 'integer', 'exists:App\Models\BannerTemplate,id'],
             'x_coordinate.*' => ['sometimes', 'nullable', 'integer', 'min:0', 'max:'.$banner_template->template->width],

--- a/laravel/app/Models/BannerTemplate.php
+++ b/laravel/app/Models/BannerTemplate.php
@@ -19,6 +19,7 @@ class BannerTemplate extends Model
     protected $fillable = [
         'banner_id',
         'template_id',
+        'redirect_url',
         'enabled',
     ];
 

--- a/laravel/database/factories/BannerTemplateFactory.php
+++ b/laravel/database/factories/BannerTemplateFactory.php
@@ -17,6 +17,7 @@ class BannerTemplateFactory extends Factory
     public function definition(): array
     {
         return [
+            'redirect_url' => fake()->url(),
             'enabled' => fake()->boolean(),
         ];
     }

--- a/laravel/database/migrations/2023_08_17_012100_add_redirect_url_column_to_banner_templates.php
+++ b/laravel/database/migrations/2023_08_17_012100_add_redirect_url_column_to_banner_templates.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('banner_templates', function (Blueprint $table) {
+            $table->string('redirect_url')->nullable()->after('template_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('banner_templates', function (Blueprint $table) {
+            $table->dropColumn('redirect_url');
+        });
+    }
+};

--- a/laravel/resources/views/banner/configuration.blade.php
+++ b/laravel/resources/views/banner/configuration.blade.php
@@ -68,6 +68,21 @@
                         @csrf
                         <input type="hidden" name="banner_template_id" value="{{ $banner_template->id }}">
 
+                        <div class="col-md-12">
+                            <label for="validationRedirectUrl" class="form-label">Redirect URL</label>
+                            <div class="input-group">
+                                <input class="form-control" id="validationRedirectUrl" type="url" name="redirect_url" value="{{ old('redirect_url', (isset($banner_template)) ? $banner_template->redirect_url : '') }}" placeholder="e.g. https://example.com/news" aria-describedby="redirectUrlHelp">
+                                <a href="{{ route('api.banner.redirect_url', ['banner_id' => base_convert($banner_template->banner_id, 10, 35), 'banner_template_id' => $banner_template->id]) }}" target="_blank" class="btn btn-primary">Test Redirect</a>
+                            </div>
+                            <div id="redirectUrlHelp" class="form-text">An optional URL, where the user should get redirected, when he clicks on the banner. By default, the rendered template will be opened.</div>
+                            <div class="valid-feedback">{{ __("Looks good!") }}</div>
+                            <div class="invalid-feedback">{{ __("Please provide a valid URL.") }}</div>
+                        </div>
+
+                        <p>For this functionality you need to configure the following URL as Hostbanner URL on your TeamSpeak server: <code>{{ route('api.banner.redirect_url', ['banner_id' => base_convert($banner_template->banner_id, 10, 35)]) }}</code></p>
+
+                        <hr>
+
                         @if ($banner_template->configurations->count() > 0)
                             @foreach ($banner_template->configurations as $configuration)
                                 <div id="config-row-{{ $configuration->id }}">

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -16,4 +16,6 @@ use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->group(function () {
     Route::get('/banner/{banner_id}', [BannerController::class, 'get_rendered_template'])->name('api.banner');
+
+    Route::get('/banner/{banner_id}/redirect-url', [BannerController::class, 'redirect_url'])->name('api.banner.redirect_url');
 });


### PR DESCRIPTION
This change introduces a new API endpoint (URL) for each banner, which can be configured as "Hostbanner URL" in TeamSpeak.

In each banner configuration you can specify, if this should open the banner image, which the client can see at the moment or if the client should get redirected to any other URL.

You can for example create one banner with multiple templates and each template redirects to a different URL.

![image](https://github.com/Sebbo94BY/teamspeak-dynamic-banner/assets/5154682/1db729a0-65fa-45e3-952c-33c0d4deb968)
