### PR TITLE
Show rendered banner if only disabled

### DIFF
--- a/laravel/resources/views/banner/template.blade.php
+++ b/laravel/resources/views/banner/template.blade.php
@@ -41,8 +41,8 @@
                             @foreach($templates as $template)
                             <tr>
                                 <td>
-                                    @if ($template->isEnabledForBannerId($banner->id))
-                                    <img class="img-fluid shadow-lg p-1 mb-2 bg-white rounded opacity-100" style="max-height: 200px;" src="{{ asset($template->file_path_drawed_text.'/'.$template->filename) }}" alt="{{ $template->alias }}">
+                                    @if ($template->isUsedByBannerId($banner->id))
+                                    <img class="img-fluid shadow-lg p-1 mb-2 bg-white rounded opacity-{{ ($template->isEnabledForBannerId($banner->id)) ? 100 : 50 }}" style="max-height: 200px;" src="{{ asset($template->file_path_drawed_text.'/'.$template->filename) }}" alt="{{ $template->alias }}">
                                     @else
                                     <img class="img-fluid shadow-lg p-1 mb-2 bg-white rounded opacity-50" style="max-height: 200px;" src="{{ asset($template->file_path_original.'/'.$template->filename) }}" alt="{{ $template->alias }}">
                                     @endif


### PR DESCRIPTION
When you add and configure a template for a banner, you see it with the last saved information in the overview.

When you disabled it, an empty template was shown and you had to open its configuration in order to see, what is configured for it.

With this change, you will still see the preview with the last saved text, so that you don't have to open its configuration first.