### PR TITLE
Automatically wrap too long text on templates

### DIFF
--- a/laravel/app/Http/Controllers/Helpers/DrawTextOnTemplateController.php
+++ b/laravel/app/Http/Controllers/Helpers/DrawTextOnTemplateController.php
@@ -91,6 +91,16 @@ class DrawTextOnTemplateController extends Controller
                     }
                 }
 
+                // Calculate required text width in pixel
+                $text_bounding_box = imagettfbbox($configuration->font_size, $configuration->font_angle, public_path($configuration->fontfile_path), $text);
+                $total_text_width_in_pixel = $text_bounding_box[2];
+
+                // Avoid writing text outside of the template. Instead, automatically wrap the text.
+                if ($configuration->x_coordinate + $total_text_width_in_pixel >= $banner_template->template->width) {
+                    $word_wrap_width = intval(($banner_template->template->width - $configuration->x_coordinate) / $total_text_width_in_pixel * 100);
+                    $text = wordwrap($text, $word_wrap_width, "\n", false);
+                }
+
                 if (! imagefttext($this->gd_image,
                     $configuration->font_size,
                     $configuration->font_angle,


### PR DESCRIPTION
If you have text with line breaks or which need line breaks on your templates, you have to add each line to an extra configuration with new X-Y-Coordinates and font settings.

This change improves this by automatically wrapping too long text, which would not fit on the template without any line break. This is automatically done based on the font size, text length, X-Coordinate and template width.

Refs:
- https://www.php.net/manual/en/function.imagettfbbox.php
- https://www.php.net/manual/en/function.wordwrap.php