### PR TITLE
Fix incorrect time in banners

### DIFF
--- a/laravel/app/Http/Controllers/Helpers/BannerVariableController.php
+++ b/laravel/app/Http/Controllers/Helpers/BannerVariableController.php
@@ -38,7 +38,7 @@ class BannerVariableController extends Controller
      */
     public function get_current_time_data(): array
     {
-        $current_datetime = Carbon::now();
+        $current_datetime = Carbon::now()->addMinute();
 
         $datetimes = [
             'current_time_utc_hi' => $current_datetime->setTimezone('UTC')->format('H:i'),


### PR DESCRIPTION
Even with the highest refresh rate of the banner in TeamSpeak, the client always gets the current time minus a minute, although we already update the variable every 15 seconds. This change ensures, that the time is more accurate on the banner.