### PR TITLE
Issue #118: Fix incorrect rule definition

### DIFF
--- a/laravel/app/Http/Requests/BannerConfigurationUpsertRequest.php
+++ b/laravel/app/Http/Requests/BannerConfigurationUpsertRequest.php
@@ -39,7 +39,7 @@ class BannerConfigurationUpsertRequest extends FormRequest
             'configuration.y_coordinate' => ['required', 'array', 'min:1'],
             'configuration.y_coordinate.*' => ['integer', 'min:0', 'max:'.$banner_template->template->height],
 
-            'configuration.text.*' => ['required', 'array', 'min:1'],
+            'configuration.text' => ['required', 'array', 'min:1'],
             'configuration.text.*' => ['string', 'max:255'],
 
             'configuration.fontfile_path' => ['required', 'array', 'min:1'],


### PR DESCRIPTION
The first definition should ensure, that it is an array with at least one element. The second definition should check the actual content of this element.

Closes #118.