### PR TITLE
Fix `No such file or directory` in `create_fonts_table` migration

### DIFF
--- a/laravel/database/migrations/2023_09_03_135919_create_fonts_table.php
+++ b/laravel/database/migrations/2023_09_03_135919_create_fonts_table.php
@@ -32,6 +32,10 @@ return new class extends Migration
             $table->timestamps();
         });
 
+        if (! file_exists(public_path($this->upload_directory))) {
+            mkdir(public_path($this->upload_directory), 0755, true);
+        }
+
         foreach (array_filter(Storage::disk('public')->files('fonts/'), $this->is_ttf_file(...), ARRAY_FILTER_USE_BOTH) as $fontfile_path) {
             // Move the manually uploaded file from the old into the new directory
             rename(


### PR DESCRIPTION
Running `php artisan migrate` causes the following error:
```shell
   INFO  Running migrations.  

  2023_09_03_135919_create_fonts_table ................................................................................................... 51ms FAIL

In 2023_09_03_135919_create_fonts_table.php line 37:

  rename(/var/www/laravel/public/fonts/universe-ce-45-light.ttf,/var/www/laravel/public/uploads/fonts/universe-ce-45-light.ttf): No such  
   file or directory
```

This pull request fixes this issue.