### PR TITLE
Fix `Data too long for column 'serverquery_password'`

### DIFF
--- a/laravel/database/migrations/2023_09_10_162338_change_serverquery_password_column_type_in_instances_table.php
+++ b/laravel/database/migrations/2023_09_10_162338_change_serverquery_password_column_type_in_instances_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instances', function (Blueprint $table) {
+            $table->text('serverquery_password')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instances', function (Blueprint $table) {
+            $table->string('serverquery_password')->change();
+        });
+    }
+};


### PR DESCRIPTION
Sometimes, the ServerQuery password couldn't be stored encrypted in the database as the column was too small. This change fixes this issue by changing the column type.