### PR TITLE
Issue #148: Force LF EoL

### DIFF
--- a/laravel/.gitattributes
+++ b/laravel/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text eol=lf
 
 *.blade.php diff=html
 *.css diff=css


### PR DESCRIPTION
This application only runs on Linux, so we should force the End of Line to the Linux LF.

All currently committed files have already the LF, so there are no further actions required. Example:
```shell
$ file docker/scripts/prepare-docker-setup.sh
docker/scripts/prepare-docker-setup.sh: Bourne-Again shell script, ASCII text executable
```

```shell
$ git ls-files --eol docker/scripts/prepare-docker-setup.sh 
i/lf    w/lf    attr/                   docker/scripts/prepare-docker-setup.sh
```

Further information: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings