### PR TITLE
Show config app name instead of "Dynamic Banner"

### DIFF
--- a/laravel/resources/views/layouts/nav-main.blade.php
+++ b/laravel/resources/views/layouts/nav-main.blade.php
@@ -1,7 +1,7 @@
 @guest()
 <nav class="navbar navbar-dark bg-dark navbar-expand-lg">
     <div class="container">
-        <a class="navbar-brand" href="{{Route('dashboard')}}">Dynamic Banner</a>
+        <a class="navbar-brand" href="{{Route('dashboard')}}">{{ config('app.name') }}</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
@@ -40,7 +40,7 @@
 @auth()
 <nav class="navbar navbar-dark bg-dark navbar-expand-lg">
     <div class="container">
-        <a class="navbar-brand" href="{{Route('dashboard')}}">Dynamic Banner</a>
+        <a class="navbar-brand" href="{{Route('dashboard')}}">{{ config('app.name') }}</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>


### PR DESCRIPTION
You can already set the `APP_NAME` in your `.env` file to give this application an individual name, which is also displayed in the browser tab.

Now it even gets displayed in the head navigation:

![image](https://github.com/Sebbo94BY/teamspeak-dynamic-banner/assets/5154682/7159761a-6269-466c-8595-7fb01feba229)
