### PR TITLE
Add support for animated GIF images in banners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libjpeg-dev \
     libjpeg62-turbo-dev \
     libpng-dev \
+    ffmpeg \
     libonig-dev \
     libxml2-dev \
     libssh2-1-dev \

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Be a [stargazer](https://github.com/Sebbo94BY/teamspeak-dynamic-banner/stargazer
     * Supports the ServerQuery protocol RAW and SSH
     * Define the client nickname
     * Define the default channel, where the client should be in when connected
-* Upload one or more images as templates
+* Upload one or more images of the type PNG, JPEG or (animated) GIF as templates
 * Define one or more banners (each gets a dedicated link)
     * Supports various rotation configurations
         * Non-Random: Every client, which requests the banner, will always see the same template as all other clients.
@@ -103,6 +103,9 @@ After configuring it, don't forget to cache your configuration: `php artisan con
 * Git
 * [Composer](https://getcomposer.org/)
 * [npm](https://www.npmjs.com/) (Version 9.x or newer)
+* [FFmpeg](https://ffmpeg.org/) to support animated GIFs as template
+    * This is only required, if you want to use (animated) GIF images as templates for your banners
+    * Your environment variable `PATH` should include the path to your `ffmpeg` binary
 
 
 ## TeamSpeak Permissions

--- a/laravel/app/Http/Controllers/Helpers/DrawTextOnTemplateController.php
+++ b/laravel/app/Http/Controllers/Helpers/DrawTextOnTemplateController.php
@@ -20,17 +20,88 @@ class DrawTextOnTemplateController extends Controller
      */
     protected string $upload_directory = 'uploads/fonts';
 
-    protected ?GdImage $gd_image = null;
+    /**
+     * Replace variables with actual values.
+     */
+    protected function replace_variables_with_actual_values(string $text, array $variables_and_values): string
+    {
+        if (preg_match_all("/%[A-Z0-9\_?]+%/", $text, $text_variables)) {
+            foreach ($text_variables[0] as $variable) {
+                $variable_name = strtoupper(str_replace('%', '', $variable));
+
+                if (array_key_exists($variable_name, $variables_and_values)) {
+                    $text = str_replace("$variable", $variables_and_values[$variable_name], $text);
+                } else {
+                    $text = str_replace("$variable", 'Unknown', $text);
+                }
+            }
+        }
+
+        return $text;
+    }
 
     /**
-     * The class destructor
+     * Draws text on a static image.
      */
-    public function __destruct()
+    protected function draw_text_on_static_image(GdImage $gd_image, BannerTemplate $banner_template, array $variables_and_values): GdImage
     {
-        // Destroy generated image to free up the memory
-        if (($this->gd_image !== null) and ($this->gd_image !== false)) {
-            imagedestroy($this->gd_image);
+        if ($gd_image === false) {
+            throw new Exception('Failed to load the source template as image object.');
         }
+
+        // Write all configured texts to the image
+        foreach ($banner_template->configurations as $configuration) {
+            // Convert HEX to RGB color code(s) and set it as text font color
+            list($red, $green, $blue) = sscanf($configuration->font_color_in_hexadecimal, '#%02x%02x%02x');
+            $font_color = imagecolorallocate($gd_image, $red, $green, $blue);
+
+            if ($font_color === false) {
+                throw new Exception('Failed to allocate the color for the text.');
+            }
+
+            // Search for variables (`%SAMPLE_VARIABLE%`) and replace it with their current value, if possible
+            $text = $this->replace_variables_with_actual_values($configuration->text, $variables_and_values);
+
+            // Calculate required text width in pixel
+            $text_bounding_box = imagettfbbox($configuration->font_size, $configuration->font_angle, public_path($this->upload_directory.DIRECTORY_SEPARATOR.$configuration->font->filename), $text);
+            $total_text_width_in_pixel = $text_bounding_box[2];
+
+            // Avoid writing text outside of the template. Instead, automatically wrap the text.
+            if ($configuration->x_coordinate + $total_text_width_in_pixel >= $banner_template->template->width) {
+                $word_wrap_width = intval(($banner_template->template->width - $configuration->x_coordinate) / $total_text_width_in_pixel * 100);
+                $text = wordwrap($text, $word_wrap_width, "\n", false);
+            }
+
+            if (! imagefttext($gd_image,
+                $configuration->font_size,
+                $configuration->font_angle,
+                $configuration->x_coordinate,
+                $configuration->y_coordinate,
+                $font_color,
+                public_path($this->upload_directory.DIRECTORY_SEPARATOR.$configuration->font->filename),
+                $text
+            )) {
+                throw new Exception("Failed to write the text `$text` to the image.");
+            }
+        }
+
+        return $gd_image;
+    }
+
+    /**
+     * Draw text on a(n) (animated) GIF image.
+     */
+    protected function draw_text_on_animated_image(string $source_image_filepath, string $target_image_filepath, BannerTemplate $banner_template, array $variables_and_values): void
+    {
+        $text_configs = [];
+        foreach ($banner_template->configurations as $configuration) {
+            // Search for variables (`%SAMPLE_VARIABLE%`) and replace it with their current value, if possible
+            $text = $this->replace_variables_with_actual_values($configuration->text, $variables_and_values);
+
+            $text_configs[] = "drawtext=text='$text':fontsize=$configuration->font_size:x=$configuration->x_coordinate:y=$configuration->y_coordinate:fontcolor=$configuration->font_color_in_hexadecimal:fontfile=".public_path($this->upload_directory.DIRECTORY_SEPARATOR.$configuration->font->filename);
+        }
+
+        shell_exec("ffmpeg -hide_banner -loglevel error -nostdin -y -i $source_image_filepath -vf \"".implode(',', $text_configs)."\" $target_image_filepath 2>&1");
     }
 
     /**
@@ -63,75 +134,58 @@ class DrawTextOnTemplateController extends Controller
         $variables_and_values = array_merge($variables_and_values, $banner_variable_helper->get_client_specific_info_from_cache($banner_template->banner->instance, $ip_address));
 
         foreach ($files_to_update as $source_path => $target_path) {
-            // Load template as GDImage to be able to modify it
-            $source_image_filepath = $source_path.'/'.$banner_template->template->filename;
-            $source_image_file_extension = strtolower(pathinfo($source_image_filepath, PATHINFO_EXTENSION));
-            $this->gd_image = ($source_image_file_extension == 'png') ? imagecreatefrompng(public_path($source_image_filepath)) : imagecreatefromjpeg(public_path($source_image_filepath));
-
-            if ($this->gd_image === false) {
-                throw new Exception('Failed to load the source template as image object.');
-            }
-
-            // Write all configured texts to the image
-            foreach ($banner_template->configurations as $configuration) {
-                // Convert HEX to RGB color code(s) and set it as text font color
-                list($red, $green, $blue) = sscanf($configuration->font_color_in_hexadecimal, '#%02x%02x%02x');
-                $font_color = imagecolorallocate($this->gd_image, $red, $green, $blue);
-
-                if ($font_color === false) {
-                    throw new Exception('Failed to allocate the color for the text.');
-                }
-
-                // Search for variables (`%SAMPLE_VARIABLE%`) and replace it with their current value, if possible
-                $text = $configuration->text;
-
-                if (preg_match_all("/%[A-Z0-9\_?]+%/", $text, $text_variables)) {
-                    foreach ($text_variables[0] as $variable) {
-                        $variable_name = strtoupper(str_replace('%', '', $variable));
-
-                        if (array_key_exists($variable_name, $variables_and_values)) {
-                            $text = str_replace("$variable", $variables_and_values[$variable_name], $text);
-                        } else {
-                            $text = str_replace("$variable", 'Unknown', $text);
-                        }
-                    }
-                }
-
-                // Calculate required text width in pixel
-                $text_bounding_box = imagettfbbox($configuration->font_size, $configuration->font_angle, public_path($this->upload_directory.DIRECTORY_SEPARATOR.$configuration->font->filename), $text);
-                $total_text_width_in_pixel = $text_bounding_box[2];
-
-                // Avoid writing text outside of the template. Instead, automatically wrap the text.
-                if ($configuration->x_coordinate + $total_text_width_in_pixel >= $banner_template->template->width) {
-                    $word_wrap_width = intval(($banner_template->template->width - $configuration->x_coordinate) / $total_text_width_in_pixel * 100);
-                    $text = wordwrap($text, $word_wrap_width, "\n", false);
-                }
-
-                if (! imagefttext($this->gd_image,
-                    $configuration->font_size,
-                    $configuration->font_angle,
-                    $configuration->x_coordinate,
-                    $configuration->y_coordinate,
-                    $font_color,
-                    public_path($this->upload_directory.DIRECTORY_SEPARATOR.$configuration->font->filename),
-                    $text
-                )) {
-                    throw new Exception("Failed to write the text `$text` to the image.");
-                }
-            }
-
-            // Return the generated image or write it to the storage
+            // Permanently or temporary write it to the storage
             if ($write_to_filesystem) {
-                $image_file_path = public_path($target_path.'/'.$banner_template->template->filename);
+                $image_file_path = public_path($target_path).'/'.$banner_template->template->filename;
             } else {
                 $image_file_path = tempnam(sys_get_temp_dir(), 'DynamicBanner_');
                 DeleteTemporaryRenderedBannerTemplates::dispatch($image_file_path)->delay(now()->addMinutes(1));
             }
 
-            if ($source_image_file_extension == 'png') {
-                imagepng($this->gd_image, $image_file_path, 0);
-            } else {
-                imagejpeg($this->gd_image, $image_file_path, 100);
+            // Identify file type and handle respectively the drawing of the grid system
+            $source_image_filepath = public_path($source_path).'/'.$banner_template->template->filename;
+            $source_image_file_extension = strtolower(pathinfo($source_image_filepath, PATHINFO_EXTENSION));
+
+            switch ($source_image_file_extension) {
+                case 'png':
+                    // Save the generated image as file
+                    $gd_image = imagecreatefrompng($source_image_filepath);
+                    if (! imagepng($this->draw_text_on_static_image($gd_image, $banner_template, $variables_and_values), public_path($target_path).'/'.$banner_template->template->filename, 0)) {
+                        throw new Exception("Could not save the template with the drawed text to `$target_path`.");
+                    }
+
+                    imagepng($gd_image, $image_file_path, 0);
+
+                    // Destroy the generated image to free up the memory again
+                    imagedestroy($gd_image);
+
+                    break;
+
+                case 'jpg':
+                case 'jpeg':
+                    // Save the generated image as file
+                    $gd_image = imagecreatefromjpeg($source_image_filepath);
+                    if (! imagejpeg($this->draw_text_on_static_image($gd_image, $banner_template, $variables_and_values), public_path($target_path).'/'.$banner_template->template->filename, 100)) {
+                        throw new Exception("Could not save the template with the drawed text to `$target_path`.");
+                    }
+
+                    imagejpeg($gd_image, $image_file_path, 100);
+
+                    // Destroy the generated image to free up the memory again
+                    imagedestroy($gd_image);
+
+                    break;
+
+                case 'gif':
+                    // For the API the temporary file must be suffixed with `.gif` as the browser will otherwise not show any GIF.
+                    // Instead you see a white page and HTTP 200 response with Content-Type `image/gif`.
+                    $image_file_path = (str_ends_with($image_file_path, '.gif')) ? $image_file_path : $image_file_path.'.gif';
+                    $this->draw_text_on_animated_image($source_image_filepath, $image_file_path, $banner_template, $variables_and_values);
+
+                    break;
+
+                default:
+                    throw new Exception("The uploaded file `$source_image_filepath` is not supported by this application and can not be used.");
             }
         }
 

--- a/laravel/app/Http/Requests/TemplateAddRequest.php
+++ b/laravel/app/Http/Requests/TemplateAddRequest.php
@@ -15,7 +15,7 @@ class TemplateAddRequest extends FormRequest
     {
         return [
             'alias' => ['required', 'string'],
-            'file' => ['required', 'image', 'mimes:png,jpg,jpeg', 'dimensions:min_width=468,min_height=60,max_width=1024,max_height=300', 'max:5120'],
+            'file' => ['required', 'image', 'mimes:png,jpg,jpeg,gif', 'dimensions:min_width=468,min_height=60,max_width=1024,max_height=300', 'max:5120'],
         ];
     }
 }

--- a/laravel/app/Http/Requests/TemplateUpdateRequest.php
+++ b/laravel/app/Http/Requests/TemplateUpdateRequest.php
@@ -26,7 +26,7 @@ class TemplateUpdateRequest extends FormRequest
         return [
             'template_id' => ['required', 'integer', 'exists:App\Models\Template,id'],
             'alias' => ['required', 'string'],
-            'file' => ['nullable', 'image', 'mimes:png,jpg,jpeg', 'dimensions:min_width=468,min_height=60,max_width=1024,max_height=300', 'max:5120'],
+            'file' => ['nullable', 'image', 'mimes:png,jpg,jpeg,gif', 'dimensions:min_width=468,min_height=60,max_width=1024,max_height=300', 'max:5120'],
         ];
     }
 }

--- a/laravel/database/factories/TemplateFactory.php
+++ b/laravel/database/factories/TemplateFactory.php
@@ -16,9 +16,11 @@ class TemplateFactory extends Factory
      */
     public function definition(): array
     {
+        $random_name = str_replace('.', '', fake()->text(32));
+
         return [
-            'alias' => fake()->text(32),
-            'filename' => str_replace(' ', '_', fake()->text(32)).'.png',
+            'alias' => $random_name,
+            'filename' => str_replace(' ', '_', $random_name).'.png',
             'file_path_original' => 'uploads/templates',
             'file_path_drawed_grid' => 'uploads/templates/drawed_grid',
             'width' => fake()->numberBetween(468, 1024),

--- a/laravel/lang/de/views/inc/system/systemstatus.php
+++ b/laravel/lang/de/views/inc/system/systemstatus.php
@@ -31,6 +31,8 @@ return [
     'accordion_section_php' => 'PHP',
     'accordion_section_php_version' => 'PHP Version',
     'accordion_section_php_extensions' => 'PHP Erweiterungen',
+    'accordion_section_php_ini_disable_functions_current_value_empty_list' => 'Leere Liste',
+    'accordion_section_php_ini_disable_functions_required_value' => '`shell_exec` sollte nicht gelistet sein',
     'accordion_section_php_ini_date_timezone_required_value' => 'sollte gesetzt sein',
 
     /**
@@ -64,6 +66,14 @@ return [
     'accordion_section_redis_connection_current_value_connected' => 'Verbunden',
     'accordion_section_redis_connection_current_value_error' => 'Fehler: :exception',
     'accordion_section_redis_connection_required_value' => '`.env` sollte gültige `REDIS_` Einstellungen haben',
+
+    /**
+     * Accordion Section "FFMpeg"
+     */
+    'accordion_section_ffmpeg' => 'FFMpeg (GIF Unterstützung)',
+    'accordion_section_ffmpeg_version' => 'FFMpeg Version',
+    'accordion_section_ffmpeg_version_current_value_error' => 'FFMpeg ist entweder nicht installiert oder `shell_exec()` ist deaktiviert',
+    'accordion_section_ffmpeg_version_required_value' => '`FFMpeg` sollte installiert sein, um GIF Vorlagen zu unterstützen',
 
     /**
      * Accordion Section "Version"

--- a/laravel/lang/de/views/modals/templates/modal-add.php
+++ b/laravel/lang/de/views/modals/templates/modal-add.php
@@ -15,7 +15,7 @@ return [
     'alias_help' => 'Ein Alias für die Vorlage. (Nur eine Information für dich.)',
 
     'template_file' => 'Vorlagendatei',
-    'template_file_help' => 'Die Vorlagendatei. (min. 468x60px (Breite x Höhe), max. 1024x300px (Breite x Höhe), PNG/JPEG, max. 5 MB)',
+    'template_file_help' => 'Die Vorlagendatei. (min. 468x60px (Breite x Höhe), max. 1024x300px (Breite x Höhe), PNG/JPEG/GIF, max. 5 MB)',
 
     /**
      * Buttons

--- a/laravel/lang/de/views/modals/templates/modal-edit.php
+++ b/laravel/lang/de/views/modals/templates/modal-edit.php
@@ -15,7 +15,7 @@ return [
     'alias_help' => 'Ein Alias für die Vorlage. (Nur eine Information für dich.)',
 
     'template_file' => 'Vorlagendatei',
-    'template_file_help' => 'Die Vorlagendatei. (min. 468x60px (Breite x Höhe), max. 1024x300px (Breite x Höhe), PNG/JPEG, max. 5 MB)',
+    'template_file_help' => 'Die Vorlagendatei. (min. 468x60px (Breite x Höhe), max. 1024x300px (Breite x Höhe), PNG/JPEG/GIF, max. 5 MB)',
 
     /**
      * Buttons

--- a/laravel/lang/en/views/inc/system/systemstatus.php
+++ b/laravel/lang/en/views/inc/system/systemstatus.php
@@ -31,6 +31,8 @@ return [
     'accordion_section_php' => 'PHP',
     'accordion_section_php_version' => 'PHP Version',
     'accordion_section_php_extensions' => 'PHP Extensions',
+    'accordion_section_php_ini_disable_functions_current_value_empty_list' => 'Empty list',
+    'accordion_section_php_ini_disable_functions_required_value' => '`shell_exec` should not be listed',
     'accordion_section_php_ini_date_timezone_required_value' => 'should be set',
 
     /**
@@ -64,6 +66,14 @@ return [
     'accordion_section_redis_connection_current_value_connected' => 'Connected',
     'accordion_section_redis_connection_current_value_error' => 'Error: :exception',
     'accordion_section_redis_connection_required_value' => '`.env` should contain valid `REDIS_` settings',
+
+    /**
+     * Accordion Section "FFMpeg"
+     */
+    'accordion_section_ffmpeg' => 'FFMpeg (GIF Support)',
+    'accordion_section_ffmpeg_version' => 'FFMpeg Version',
+    'accordion_section_ffmpeg_version_current_value_error' => 'FFMpeg is either not installed or `shell_exec()` is disabled',
+    'accordion_section_ffmpeg_version_required_value' => '`FFMpeg` should be installed to support GIF templates',
 
     /**
      * Accordion Section "Version"

--- a/laravel/lang/en/views/modals/templates/modal-add.php
+++ b/laravel/lang/en/views/modals/templates/modal-add.php
@@ -15,7 +15,7 @@ return [
     'alias_help' => 'An alias for the template. (Only an information for you.)',
 
     'template_file' => 'Template file',
-    'template_file_help' => 'The template file. (min. 468x60px (Width x Height), max. 1024x300px (Width x Height), PNG/JPEG, max. 5 MB)',
+    'template_file_help' => 'The template file. (min. 468x60px (Width x Height), max. 1024x300px (Width x Height), PNG/JPEG/GIF, max. 5 MB)',
 
     /**
      * Buttons

--- a/laravel/lang/en/views/modals/templates/modal-edit.php
+++ b/laravel/lang/en/views/modals/templates/modal-edit.php
@@ -15,7 +15,7 @@ return [
     'alias_help' => 'An alias for the template. (Only an information for you.)',
 
     'template_file' => 'Template file',
-    'template_file_help' => 'The template file. (min. 468x60px (Width x Height), max. 1024x300px (Width x Height), PNG/JPEG, max. 5 MB)',
+    'template_file_help' => 'The template file. (min. 468x60px (Width x Height), max. 1024x300px (Width x Height), PNG/JPEG/GIF, max. 5 MB)',
 
     /**
      * Buttons

--- a/laravel/resources/views/inc/system/systemstatus.blade.php
+++ b/laravel/resources/views/inc/system/systemstatus.blade.php
@@ -315,6 +315,61 @@
                 </div>
             </div>
         </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="accordionSystemStatusFfmpegHeading">
+                <a class="accordion-button collapsed fw-bold bg-light text-decoration-none @if($ffmpeg_warning_count == 0  && $ffmpeg_error_count == 0 ) collapsed @endif" type="button" data-bs-toggle="collapse" data-bs-target="#accordionSystemStatusFfmpeg" aria-expanded="false" aria-controls="accordionSystemStatusFfmpeg">
+                    <div class="col-lg-9">
+                        <span class="fs-5 fw-bold text-dark">{{ __('views/inc/system/systemstatus.accordion_section_ffmpeg') }}</span>
+                    </div>
+                    <div class="col-lg-2 me-5">
+                        @if($ffmpeg_error_count > 0)
+                            <span class="fs-5 fw-bold text-danger"><i class="fa fa-circle-xmark"></i> {{ __('views/inc/system/systemstatus.accordion_error') }}</span>
+                        @elseif($ffmpeg_warning_count > 0)
+                            <span class="fs-5 fw-bold text-warning"><i class="fa fa-triangle-exclamation"></i> {{ __('views/inc/system/systemstatus.accordion_warning') }}</span>
+                        @else
+                            <span class="fs-5 fw-bold text-success"><i class="fa fa-check-circle"></i> {{ __('views/inc/system/systemstatus.accordion_operational') }}</span>
+                        @endif
+                    </div>
+                </a>
+            </h2>
+            <div id="accordionSystemStatusFfmpeg" class="accordion-collapse collapse @if($ffmpeg_warning_count > 0  || $ffmpeg_error_count > 0 ) show @endif" aria-labelledby="accordionSystemStatusFfmpegHeading">
+                <div class="accordion-body bg-light">
+                    <div class="col-lg-12">
+                        <table class="table table-striped">
+                            <thead>
+                            <tr>
+                                <th class="col-lg-6 border-0" scope="col"></th>
+                                <th class="col-lg-6 border-0" scope="col"></th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @foreach($ffmpeg_version as $key => $ffmpeg_version)
+                                <tr>
+                                    <td class="border-0">{{$ffmpeg_version->name}} <code>{{$ffmpeg_version->required_value}}</code></td>
+                                    <td class="border-0">
+                                        @switch($ffmpeg_version->severity)
+                                            @case('success')
+                                                <i class="fa-solid fa-check-circle text-success me-3"></i>
+                                                @break
+                                            @case('warning')
+                                                <i class="fa-solid fa-triangle-exclamation text-warning me-3"></i>
+                                                @break
+                                            @case('danger')
+                                                <i class="fa-solid fa-circle-xmark text-danger me-3"></i>
+                                                @break
+                                            @default
+                                                <i class="fa-solid fa-info-circle text-info me-3"></i>
+                                        @endswitch
+                                        {{$ffmpeg_version->current_value}}
+                                    </td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
         @if(Route::currentRouteName() != 'setup.installer.requirements')
         <div class="accordion-item">
             <h2 class="accordion-header" id="accordionSystemStatusVersionHeading">

--- a/laravel/resources/views/modals/templates/modal-add.blade.php
+++ b/laravel/resources/views/modals/templates/modal-add.blade.php
@@ -22,7 +22,7 @@
                         <div class="mb-3 row">
                             <label for="validationFile" class="col-lg-1 col-form-label fw-bold">{{ __('views/modals/templates/modal-add.template_file') }}</label>
                             <div class="col-lg-11">
-                                <input type="file" class="form-control" id="validationFile" accept="image/png, image/jpeg" name="file"
+                                <input type="file" class="form-control" id="validationFile" accept="image/png, image/jpeg @if (! preg_match('/shell_exec/', ini_get('disable_functions')) and (!is_null(@shell_exec('ffmpeg -version | head -1')) or !empty(@shell_exec('ffmpeg -version | head -1')))) , image/gif @endif" name="file"
                                        aria-describedby="validationFileHelp validationFileFeedback" value="{{ old('file') }}" required>
                                 <div id="validationFileHelp" class="form-text">{{ __('views/modals/templates/modal-add.template_file_help') }}</div>
                             </div>

--- a/laravel/resources/views/modals/templates/modal-edit.blade.php
+++ b/laravel/resources/views/modals/templates/modal-edit.blade.php
@@ -27,7 +27,7 @@
                         <div class="mb-3 row">
                             <label for="validationFile" class="col-lg-1 col-form-label fw-bold">{{ __('views/modals/templates/modal-edit.template_file') }}</label>
                             <div class="col-lg-11">
-                                <input type="file" class="form-control" id="validationFile" accept="image/png, image/jpeg"
+                                <input type="file" class="form-control" id="validationFile" accept="image/png, image/jpeg @if (! preg_match('/shell_exec/', ini_get('disable_functions')) and (!is_null(@shell_exec('ffmpeg -version | head -1')) or !empty(@shell_exec('ffmpeg -version | head -1')))) , image/gif @endif"
                                        aria-describedby="validationFileHelp validationFileFeedback-{{$templateModal->id}}"
                                        name="file" value="{{ old('file') }}" required>
                                 <div id="validationFileHelp" class="form-text">{{ __('views/modals/templates/modal-edit.template_file_help') }}</div>

--- a/laravel/tests/Feature/API/v1/BannerTest.php
+++ b/laravel/tests/Feature/API/v1/BannerTest.php
@@ -121,6 +121,9 @@ class BannerTest extends TestCase
             ->for(Font::factory()->create())
             ->create();
 
+        // Overwrite the factory default to match the actual controller path
+        $banner_template->file_path_drawed_text = 'uploads/templates/drawed_text/'.$banner_template->id;
+
         // Generate a temporary image to be able to test the API
         $absolut_upload_directory = public_path($banner_template->template->file_path_original);
         $image_file_path = $absolut_upload_directory.'/'.$banner_template->template->filename;
@@ -128,6 +131,10 @@ class BannerTest extends TestCase
         imagecolorallocate($gd_image, 0, 0, 0);
         if (! file_exists($absolut_upload_directory)) {
             mkdir($absolut_upload_directory, 0777, true);
+        }
+        $absolut_drawed_text_directory = public_path($banner_template->file_path_drawed_text).'/'.$banner_template->template->filename;
+        if (! file_exists($absolut_drawed_text_directory)) {
+            mkdir($absolut_drawed_text_directory, 0777, true);
         }
         imagepng($gd_image, $image_file_path);
 
@@ -139,7 +146,7 @@ class BannerTest extends TestCase
         $response->assertHeader('Expires', '-1');
         $response->assertHeader('ETag');
         $response->assertHeader('Last-Modified');
-        $this->assertContains($response->headers->get('Content-Type'), ['image/png', 'image/jpeg']);
+        $this->assertContains($response->headers->get('Content-Type'), ['image/png', 'image/jpeg', 'image/gif']);
         $response->assertStatus(200);
 
         // Delete temporary files again


### PR DESCRIPTION
This pull request adds support for animated GIF images, so that you can use animated GIF based templates in your banner configurations.

Requirements / Setup Instructions:

1. Install https://ffmpeg.org/ on your Linux system (either via your operating systems package manager like `apt` or by following a installation documentation from their homepage)
2. Afterwards please ensure, that the path to the `ffmpeg` binary is part of the operating systems `PATH` environment variable, so that the following command succeeds on your command line: `ffmpeg -version`
3. Check the System Status page of your Dynamic Banner installation and check the status of `FFMpeg (GIF Support)` - it should be `Operational`
4. If everything went fine, you should now be able to upload a(n animated) GIF as template, which you can then use in your banners

Todo:
- [x] Drawing lines / Writing text on the animated GIF image breaks the file and only returns a static file (first frame of the GIF), so it's not animated anymore. Waiting for feedback and hopefully a solution: https://stackoverflow.com/questions/77208057/draw-lines-and-write-text-on-animated-gif-image-using-php

Closes #171