### PR TITLE
Docker: Specify `client_max_body_size`

### DIFF
--- a/docker/nginx/localhost.conf
+++ b/docker/nginx/localhost.conf
@@ -10,6 +10,7 @@ server {
     index index.php;
  
     charset utf-8;
+    client_max_body_size 5M;
  
     location / {
         try_files $uri $uri/ /index.php?$query_string;


### PR DESCRIPTION
This explicitly defines the maximum body size for HTTP requests. File uploads can reach this limit for example.