### PR TITLE
Add support for time-based configurations

### DIFF
--- a/laravel/app/Console/Commands/Banners/DisableBannerTemplate.php
+++ b/laravel/app/Console/Commands/Banners/DisableBannerTemplate.php
@@ -27,7 +27,7 @@ class DisableBannerTemplate extends Command
      */
     public function handle()
     {
-        $banner_templates_with_set_disable_at = BannerTemplate::whereNotNull('disable_at')->get(['id', 'disable_at']);
+        $banner_templates_with_set_disable_at = BannerTemplate::whereNotNull('disable_at')->get(['id', 'disable_at', 'enabled']);
 
         $this->info('Checking '.count($banner_templates_with_set_disable_at).' banner templates...');
 

--- a/laravel/app/Console/Commands/Banners/TimeBasedDisabling.php
+++ b/laravel/app/Console/Commands/Banners/TimeBasedDisabling.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Console\Commands\Banners;
+
+use App\Models\BannerTemplate;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class TimeBasedDisabling extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'banners:disable-time-based';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Disables templates of all banners, when their `time_based_disable_at` is after the current time.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $banner_templates_with_set_time_based_disable_at = BannerTemplate::whereNotNull('time_based_disable_at')->get(['id', 'time_based_enable_at', 'time_based_disable_at', 'enabled']);
+
+        $this->info('Checking '.count($banner_templates_with_set_time_based_disable_at).' banner templates...');
+
+        foreach ($banner_templates_with_set_time_based_disable_at as $banner_template) {
+            if (! $banner_template->enabled) {
+                $this->info("The banner template with the ID $banner_template->id is already disabled. Skipping.");
+                continue;
+            }
+
+            $carbon_time_based_disable_at = Carbon::parse($banner_template->time_based_disable_at);
+
+            $should_be_disabled = false;
+            if ($carbon_time_based_disable_at > Carbon::parse($banner_template->time_based_enable_at)) {
+                // Should be disabled on the same day
+                // Example: 16:00 - 20:00
+                if (Carbon::now()->lt($carbon_time_based_disable_at) and Carbon::now()->lt($banner_template->time_based_enable_at)) {
+                    $should_be_disabled = true;
+                } elseif (Carbon::now()->gt($carbon_time_based_disable_at) and Carbon::now()->gt($banner_template->time_based_enable_at)) {
+                    $should_be_disabled = true;
+                }
+            } else {
+                // Should be disabled on the next day
+                // Example: 22:00 - 01:00
+                if (Carbon::now()->gt($carbon_time_based_disable_at) and Carbon::now()->lt($banner_template->time_based_enable_at)) {
+                    $should_be_disabled = true;
+                }
+            }
+
+            if (! $should_be_disabled) {
+                $this->info("The banner template with the ID $banner_template->id should NOT be disabled yet. Skipping.");
+                continue;
+            }
+
+            $banner_template->enabled = false;
+
+            if (! $banner_template->save()) {
+                $this->error("Failed to disable the banner template with the ID $banner_template->id. See ".route('banner.template.configuration.edit', ['banner_template_id' => $banner_template->id]).' for details.');
+            }
+
+            $this->warn("Successfully disabled the banner template with the ID $banner_template->id. See ".route('banner.template.configuration.edit', ['banner_template_id' => $banner_template->id]).' for details.');
+        }
+    }
+}

--- a/laravel/app/Console/Commands/Banners/TimeBasedEnabling.php
+++ b/laravel/app/Console/Commands/Banners/TimeBasedEnabling.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Console\Commands\Banners;
+
+use App\Models\BannerTemplate;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class TimeBasedEnabling extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'banners:enable-time-based';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Enables templates of all banners, when their `time_based_enable_at` is after the current time.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $banner_templates_with_set_time_based_enable_at = BannerTemplate::whereNotNull('time_based_enable_at')->get(['id', 'time_based_enable_at', 'time_based_disable_at', 'enabled']);
+
+        $this->info('Checking '.count($banner_templates_with_set_time_based_enable_at).' banner templates...');
+
+        foreach ($banner_templates_with_set_time_based_enable_at as $banner_template) {
+            if ($banner_template->enabled) {
+                $this->info("The banner template with the ID $banner_template->id is already enabled. Skipping.");
+                continue;
+            }
+
+            $carbon_time_based_enable_at = Carbon::parse($banner_template->time_based_enable_at);
+
+            $should_be_enabled = false;
+            if ($carbon_time_based_enable_at > Carbon::parse($banner_template->time_based_disable_at)) {
+                // Should be enabled on the same day
+                // Example: 16:00 - 20:00
+                if (Carbon::now()->lt($carbon_time_based_enable_at) and Carbon::now()->lt($banner_template->time_based_disable_at)) {
+                    $should_be_enabled = true;
+                } elseif (Carbon::now()->gt($carbon_time_based_enable_at) and Carbon::now()->gt($banner_template->time_based_disable_at)) {
+                    $should_be_enabled = true;
+                }
+            } else {
+                // Should be enabled on the next day
+                // Example: 22:00 - 01:00
+                if (Carbon::now()->gt($carbon_time_based_enable_at) and Carbon::now()->lt($banner_template->time_based_disable_at)) {
+                    $should_be_enabled = true;
+                }
+            }
+
+            if (! $should_be_enabled) {
+                $this->info("The banner template with the ID $banner_template->id should NOT be enabled yet. Skipping.");
+                continue;
+            }
+
+            $banner_template->enabled = true;
+
+            if (! $banner_template->save()) {
+                $this->error("Failed to enable the banner template with the ID $banner_template->id. See ".route('banner.template.configuration.edit', ['banner_template_id' => $banner_template->id]).' for details.');
+            }
+
+            $this->warn("Successfully enabled the banner template with the ID $banner_template->id. See ".route('banner.template.configuration.edit', ['banner_template_id' => $banner_template->id]).' for details.');
+        }
+    }
+}

--- a/laravel/app/Console/Kernel.php
+++ b/laravel/app/Console/Kernel.php
@@ -61,6 +61,16 @@ class Kernel extends ConsoleKernel
         $schedule->call(function () {
             Process::start('php '.base_path().'/artisan banners:disable-templates');
         })->name('banners:automatic-disabling')->everyFiveMinutes();
+
+        // BANNERS: Time-based Enabling
+        $schedule->call(function () {
+            Process::start('php '.base_path().'/artisan banners:enable-time-based');
+        })->name('banners:enable-time-based')->everyFiveMinutes();
+
+        // BANNERS: Time-based Disabling
+        $schedule->call(function () {
+            Process::start('php '.base_path().'/artisan banners:disable-time-based');
+        })->name('banners:disable-time-based')->everyFiveMinutes();
     }
 
     /**

--- a/laravel/app/Http/Controllers/BannerConfigurationController.php
+++ b/laravel/app/Http/Controllers/BannerConfigurationController.php
@@ -39,6 +39,8 @@ class BannerConfigurationController extends Controller
         $banner_template->name = $request->name;
         $banner_template->redirect_url = $request->redirect_url;
         $banner_template->disable_at = (isset($request->disable_at)) ? Carbon::parse($request->disable_at) : null;
+        $banner_template->time_based_enable_at = (isset($request->time_based_enable_at)) ? Carbon::parse($request->time_based_enable_at) : null;
+        $banner_template->time_based_disable_at = (isset($request->time_based_disable_at)) ? Carbon::parse($request->time_based_disable_at) : null;
 
         if (! $banner_template->save()) {
             return Redirect::route('banner.template.configuration.edit', ['banner_id' => $banner_template->banner_id, 'template_id' => $banner_template->template_id])

--- a/laravel/app/Http/Requests/BannerConfigurationUpsertRequest.php
+++ b/laravel/app/Http/Requests/BannerConfigurationUpsertRequest.php
@@ -44,6 +44,8 @@ class BannerConfigurationUpsertRequest extends FormRequest
             'name' => ['required', 'string'],
             'redirect_url' => ['nullable', 'url'],
             'disable_at' => ['nullable', 'date'],
+            'time_based_enable_at' => ['nullable', 'date_format:H:i,H:i:s'],
+            'time_based_disable_at' => ['nullable', 'date_format:H:i,H:i:s'],
             'configuration' => ['required', 'array:banner_configuration_id,x_coordinate,y_coordinate,text,font_id,font_size,font_angle,font_color_in_hexadecimal'],
 
             'configuration.banner_configuration_id' => ['sometimes', 'array'],

--- a/laravel/app/Models/BannerTemplate.php
+++ b/laravel/app/Models/BannerTemplate.php
@@ -24,6 +24,8 @@ class BannerTemplate extends Model
         'file_path_drawed_text',
         'redirect_url',
         'disable_at',
+        'time_based_enable_at',
+        'time_based_disable_at',
         'enabled',
     ];
 

--- a/laravel/database/migrations/2023_09_30_205434_add_time_based_columns_to_banner_templates_table.php
+++ b/laravel/database/migrations/2023_09_30_205434_add_time_based_columns_to_banner_templates_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('banner_templates', function (Blueprint $table) {
+            $table->time('time_based_enable_at')->nullable()->after('disable_at');
+            $table->time('time_based_disable_at')->nullable()->after('time_based_enable_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('banner_templates', function (Blueprint $table) {
+            $table->dropColumn('time_based_disable_at');
+            $table->dropColumn('time_based_enable_at');
+        });
+    }
+};

--- a/laravel/lang/de/views/banner/configuration.php
+++ b/laravel/lang/de/views/banner/configuration.php
@@ -55,6 +55,13 @@ return [
     'disable_at_use_case' => 'Diese Funktion ist zum Beispiel nützlich, wenn du auf deinem Banner eine Veranstaltung für ein bestimmtes Datum (und eine bestimmte Uhrzeit) ankündigst. Wenn du hier das entsprechende Datum (und die Uhrzeit) einstellst, wird der dynamische Banner diese konfigurierte Vorlage anschließend automatisch für dich deaktivieren, so dass du sie nicht manuell deaktivieren musst.',
     'disable_at_help' => 'Definiere ein optionales Datum und eine Uhrzeit, zu der diese Konfiguration automatisch deaktiviert werden soll. Lass das Feld leer, um sie nicht automatisch zu deaktivieren.',
 
+    'time_based_de_activation_accordion_headline' => 'Zeitbasierte Aktivierung/Deaktivierung',
+    'time_based_de_activation_use_case' => 'Diese Funktion ist zum Beispiel nützlich, wenn du bestimmte Bannerkonfigurationen nur während eines bestimmten Zeitfensters anzeigen möchtest.',
+    'time_based_de_activation_enable_at' => 'Aktiviere um',
+    'time_based_de_activation_enable_at_help' => 'Lege einen optionalen Zeitpunkt fest, zu dem diese Konfiguration automatisch aktiviert werden soll. Lass diesen Wert ungesetzt, um sie nicht automatisch zu aktivieren.',
+    'time_based_de_activation_disable_at' => 'Deaktiviere um',
+    'time_based_de_activation_disable_at_help' => 'Lege einen optionalen Zeitpunkt fest, zu dem diese Konfiguration automatisch deaktiviert werden soll. Lass diesen Wert ungesetzt, um sie nicht automatisch zu deaktivieren.',
+
     'text_configurations_accordion_headline' => 'Text Konfigurationen',
 
     /**
@@ -64,5 +71,7 @@ return [
     'name_validation_error' => 'Bitte gib einen gültigen Name an!',
     'redirect_url_validation_error' => 'Bitte gib eine gültige URL an!',
     'disable_at_validation_error' => 'Bitte gib einen gültigen Zeitpunkt an!',
+    'time_based_de_activation_enable_at_validation_error' => 'Bitte gib eine gültige Zeit an!',
+    'time_based_de_activation_disable_at_validation_error' => 'Bitte gib eine gültige Zeit an!',
 
 ];

--- a/laravel/lang/en/views/banner/configuration.php
+++ b/laravel/lang/en/views/banner/configuration.php
@@ -55,6 +55,13 @@ return [
     'disable_at_use_case' => 'This function is for example useful when you announce an event on your banner for a specific date (and time). When you set here the respective date (and time) the dynamic banner will automatically disable this configured template for you afterward, so that you don\'t have to disable it manually.',
     'disable_at_help' => 'Define an optional date and time, when this configuration should be automatically disabled. Leave it unset to not automatically disable it.',
 
+    'time_based_de_activation_accordion_headline' => 'Time-Based Acivation/Deactivation',
+    'time_based_de_activation_use_case' => 'This function is for example useful when you want to show specific banner configurations only during a specific time window.',
+    'time_based_de_activation_enable_at' => 'Enable at',
+    'time_based_de_activation_enable_at_help' => 'Define an optional time, when this configuration should be automatically enabled. Leave it unset to not automatically enable it.',
+    'time_based_de_activation_disable_at' => 'Disable at',
+    'time_based_de_activation_disable_at_help' => 'Define an optional time, when this configuration should be automatically disabled. Leave it unset to not automatically disable it.',
+
     'text_configurations_accordion_headline' => 'Text Configurations',
 
     /**
@@ -64,5 +71,7 @@ return [
     'name_validation_error' => 'Please provide a valid file!',
     'redirect_url_validation_error' => 'Please provide a valid URL!',
     'disable_at_validation_error' => 'Please provide a valid datetime!',
+    'time_based_de_activation_enable_at_validation_error' => 'Please provide a valid time!',
+    'time_based_de_activation_disable_at_validation_error' => 'Please provide a valid time!',
 
 ];

--- a/laravel/resources/views/banner/configuration.blade.php
+++ b/laravel/resources/views/banner/configuration.blade.php
@@ -141,6 +141,47 @@
                         </div>
                     </div>
                     <div class="accordion-item">
+                        <h2 class="accordion-header" id="timeBasedDeActivationHeading">
+                            <a class="accordion-button collapsed text-decoration-none text-dark fw-bold bg-light" data-bs-toggle="collapse" data-bs-target="#timeBasedDeActivation" aria-expanded="false" aria-controls="timeBasedDeActivation">
+                                <div class="col-lg-9">
+                                    {{ __('views/banner/configuration.time_based_de_activation_accordion_headline') }}
+                                </div>
+                                <div class="col-lg-2 text-end">
+                                    @if(isset($banner_template) and ($banner_template->time_based_enable_at != null or $banner_template->time_based_disable_at != null))
+                                        <span class="badge text-bg-success ms-2">{{ __('views/banner/configuration.accordion_status_configured') }}</span>
+                                    @else
+                                        <span class="badge text-bg-warning ms-2">{{ __('views/banner/configuration.accordion_status_not_configured') }}</span>
+                                    @endif
+                                </div>
+                            </a>
+                        </h2>
+                        <div id="timeBasedDeActivation" class="accordion-collapse collapse" aria-labelledby="timeBasedDeActivation">
+                            <div class="accordion-body">
+                                <p class="mt-2">{{ __('views/banner/configuration.time_based_de_activation_use_case') }}</p>
+
+                                <div class="row">
+                                    <div class="col-lg-6">
+                                        <label for="validationTimeBasedEnableAt" class="form-label">{{ __('views/banner/configuration.time_based_de_activation_enable_at') }}</label>
+                                        <input class="form-control" type="time" id="validationTimeBasedEnableAt" name="time_based_enable_at"
+                                            value="{{ old('time_based_enable_at', (isset($banner_template)) ? $banner_template->time_based_enable_at : '') }}" aria-label="validationTimeBasedEnableAt">
+                                        <div class="valid-feedback">{{ __('views/banner/configuration.form_validation_looks_good') }}</div>
+                                        <div class="invalid-feedback">{{ __('views/banner/configuration.time_based_de_activation_enable_at_validation_error') }}</div>
+                                        <div class="form-text">{{ __('views/banner/configuration.time_based_de_activation_enable_at_help') }}</div>
+                                    </div>
+
+                                    <div class="col-lg-6">
+                                        <label for="validationTimeBasedDisableAt" class="form-label">{{ __('views/banner/configuration.time_based_de_activation_disable_at') }}</label>
+                                        <input class="form-control" type="time" id="validationTimeBasedDisableAt" name="time_based_disable_at"
+                                            value="{{ old('time_based_disable_at', (isset($banner_template)) ? $banner_template->time_based_disable_at : '') }}" aria-label="validationTimeBasedDisableAt">
+                                        <div class="valid-feedback">{{ __('views/banner/configuration.form_validation_looks_good') }}</div>
+                                        <div class="invalid-feedback">{{ __('views/banner/configuration.time_based_de_activation_disable_at_validation_error') }}</div>
+                                        <div class="form-text">{{ __('views/banner/configuration.time_based_de_activation_disable_at_help') }}</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="accordion-item">
                         <h2 class="accordion-header" id="bannerConfigHeading">
                             <a class="accordion-button text-decoration-none text-dark fw-bold bg-light" data-bs-toggle="collapse" data-bs-target="#bannerConfig" aria-expanded="false" aria-controls="bannerConfig">
                                 <div class="col-lg-9">

--- a/laravel/tests/Feature/Commands/Banners/TimeBasedDisablingTest.php
+++ b/laravel/tests/Feature/Commands/Banners/TimeBasedDisablingTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Commands\Banners;
+
+use App\Models\Banner;
+use App\Models\BannerTemplate;
+use App\Models\Instance;
+use App\Models\Template;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TimeBasedDisablingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected BannerTemplate $banner_template;
+
+    /**
+     * Setup the test environment.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->banner_template = BannerTemplate::factory()
+            ->for(
+                Banner::factory()->for(
+                    Instance::factory()->create()
+                )->create()
+            )
+            ->for(Template::factory()->create())
+            ->create(['enabled' => true]);
+    }
+
+    /**
+     * Test that the banner template does not get disabled when no `time_based_disable_at` timestamp has been defined.
+     */
+    public function test_banner_template_does_not_get_disabled_when_unconfigured(): void
+    {
+        $this->artisan('banners:disable-time-based')
+            ->expectsOutput('Checking 0 banner templates...')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the banner template does not get disabled when the `time_based_disable_at` timestamp has been defined, but is in the future.
+     */
+    public function test_banner_template_does_not_get_disabled_when_configured_but_in_the_future(): void
+    {
+        $this->banner_template->time_based_enable_at = Carbon::now()->subMinutes(5);
+        $this->banner_template->time_based_disable_at = Carbon::now()->addMinutes(15);
+        $this->banner_template->save();
+
+        $this->artisan('banners:disable-time-based')
+            ->expectsOutput('The banner template with the ID '.$this->banner_template->id.' should NOT be disabled yet. Skipping.')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the banner template gets disabled when the `time_based_disable_at` timestamp has been defined and is in the past.
+     */
+    public function test_banner_template_gets_disabled_when_configured_and_in_the_past(): void
+    {
+        $this->banner_template->time_based_disable_at = Carbon::now()->subMinutes(5);
+        $this->banner_template->save();
+
+        $this->artisan('banners:disable-time-based')
+            ->expectsOutput('Successfully disabled the banner template with the ID '.$this->banner_template->id.'. See '.route('banner.template.configuration.edit', ['banner_template_id' => $this->banner_template->id]).' for details.')
+            ->assertSuccessful();
+    }
+}

--- a/laravel/tests/Feature/Commands/Banners/TimeBasedEnablingTest.php
+++ b/laravel/tests/Feature/Commands/Banners/TimeBasedEnablingTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Commands\Banners;
+
+use App\Models\Banner;
+use App\Models\BannerTemplate;
+use App\Models\Instance;
+use App\Models\Template;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TimeBasedEnablingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected BannerTemplate $banner_template;
+
+    /**
+     * Setup the test environment.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->banner_template = BannerTemplate::factory()
+            ->for(
+                Banner::factory()->for(
+                    Instance::factory()->create()
+                )->create()
+            )
+            ->for(Template::factory()->create())
+            ->create(['enabled' => false]);
+    }
+
+    /**
+     * Test that the banner template does not get enabled when no `time_based_enable_at` timestamp has been defined.
+     */
+    public function test_banner_template_does_not_get_enabled_when_unconfigured(): void
+    {
+        $this->artisan('banners:enable-time-based')
+            ->expectsOutput('Checking 0 banner templates...')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the banner template does not get enabled when the `time_based_enable_at` timestamp has been defined, but is in the future.
+     */
+    public function test_banner_template_does_not_get_enabled_when_configured_but_in_the_future(): void
+    {
+        $this->banner_template->time_based_enable_at = Carbon::now()->addMinutes(5);
+        $this->banner_template->time_based_disable_at = Carbon::now()->addMinutes(15);
+        $this->banner_template->save();
+
+        $this->artisan('banners:enable-time-based')
+            ->expectsOutput('The banner template with the ID '.$this->banner_template->id.' should NOT be enabled yet. Skipping.')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the banner template gets enabled when the `time_based_enable_at` timestamp has been defined and is in the past.
+     */
+    public function test_banner_template_gets_enabled_when_configured_and_in_the_past(): void
+    {
+        $this->banner_template->time_based_enable_at = Carbon::now()->subMinutes(5);
+        $this->banner_template->save();
+
+        $this->artisan('banners:enable-time-based')
+            ->expectsOutput('Successfully enabled the banner template with the ID '.$this->banner_template->id.'. See '.route('banner.template.configuration.edit', ['banner_template_id' => $this->banner_template->id]).' for details.')
+            ->assertSuccessful();
+    }
+}


### PR DESCRIPTION
Adds support for time-based configurations in order to configure banners to be visible only during specific time windows like between 8pm and 11pm.

![image](https://github.com/Sebbo94BY/teamspeak-dynamic-banner/assets/5154682/c74bd4e8-549e-42c4-8364-adf34dc0761c)

Todo:
- [x] Implement proper if-conditions for the commands, so that they enable/disable the banners as expected (e. g. 20.00 - 22.00 is simple, but 20.00 - 02:00 is more complex)
- [x] Adjust / Add PHPUnit tests, if necessary

Closes #168