### PR TITLE
Add support for current timezone in UI

### DIFF
--- a/laravel/app/Http/Controllers/BannerConfigurationController.php
+++ b/laravel/app/Http/Controllers/BannerConfigurationController.php
@@ -38,9 +38,9 @@ class BannerConfigurationController extends Controller
         $banner_template = BannerTemplate::find($request->banner_template_id);
         $banner_template->name = $request->name;
         $banner_template->redirect_url = $request->redirect_url;
-        $banner_template->disable_at = (isset($request->disable_at)) ? Carbon::parse($request->disable_at) : null;
-        $banner_template->time_based_enable_at = (isset($request->time_based_enable_at)) ? Carbon::parse($request->time_based_enable_at) : null;
-        $banner_template->time_based_disable_at = (isset($request->time_based_disable_at)) ? Carbon::parse($request->time_based_disable_at) : null;
+        $banner_template->disable_at = (is_null($request->disable_at)) ? null : Carbon::parse($request->disable_at, $request->header('X-Timezone'))->setTimezone(config('app.timezone'));
+        $banner_template->time_based_enable_at = (is_null($request->time_based_enable_at)) ? null : Carbon::parse($request->time_based_enable_at, $request->header('X-Timezone'))->setTimezone(config('app.timezone'));
+        $banner_template->time_based_disable_at = (is_null($request->time_based_disable_at)) ? null : Carbon::parse($request->time_based_disable_at, $request->header('X-Timezone'))->setTimezone(config('app.timezone'));
 
         if (! $banner_template->save()) {
             return Redirect::route('banner.template.configuration.edit', ['banner_id' => $banner_template->banner_id, 'template_id' => $banner_template->template_id])

--- a/laravel/app/Http/Kernel.php
+++ b/laravel/app/Http/Kernel.php
@@ -37,6 +37,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\SetLocale::class,
+            \App\Http\Middleware\AddTimezoneToHeaders::class,
         ],
 
         'api' => [

--- a/laravel/app/Http/Middleware/AddTimezoneToHeaders.php
+++ b/laravel/app/Http/Middleware/AddTimezoneToHeaders.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use DateTimeZone;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class AddTimezoneToHeaders
+{
+    /**
+     * The timezone header key in HTTP requests.
+     */
+    protected string $timezone_header_key = 'X-Timezone';
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // If the HTTP request has already the required header, leave it as it is
+        if ($request->hasHeader($this->timezone_header_key)) {
+            return $next($request);
+        }
+
+        // If the user has set a preferred timezone in the user profile, use this timezone
+        if (Auth::check() and ! is_null(Auth::user()->timezone)) {
+            $request->headers->set($this->timezone_header_key, Auth::user()->timezone, true);
+
+            return $next($request);
+        }
+
+        // Set applications timezone as default timezone for clients
+        $request->headers->set($this->timezone_header_key, config('app.timezone'));
+
+        $client_preferred_language = $request->getPreferredLanguage();
+
+        if (! is_null($client_preferred_language)) {
+            // en_US => US
+            $country_code = substr($client_preferred_language, -2);
+
+            // Returns for example ['Europe/Berlin', 'Europe/Busingen']
+            $timezone = timezone_identifiers_list(DateTimeZone::PER_COUNTRY, $country_code);
+
+            // Some clients like the Microsoft Edge browser may only send 'en' as preferred language,
+            // so lets try to determine the timezone based on this value as well if the above detection
+            // did not find any possible timezone.
+            if (count($timezone) == 0) {
+                // en_US => en
+                $locale = substr($client_preferred_language, 0, 2);
+
+                $timezone = timezone_identifiers_list(DateTimeZone::PER_COUNTRY, strtoupper($locale));
+            }
+
+            // If we have found one or more timezones, set the first respectively as HTTP header
+            if (count($timezone) >= 1) {
+                $request->headers->set($this->timezone_header_key, reset($timezone), true);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Http/Requests/ProfileUpdateRequest.php
+++ b/laravel/app/Http/Requests/ProfileUpdateRequest.php
@@ -3,11 +3,22 @@
 namespace App\Http\Requests;
 
 use App\Models\User;
+use DateTimeZone;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 class ProfileUpdateRequest extends FormRequest
 {
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'timezone' => ($this->timezone == 'null') ? null : $this->timezone,
+        ]);
+    }
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -19,6 +30,7 @@ class ProfileUpdateRequest extends FormRequest
             'name' => ['string', 'max:255'],
             'email' => ['email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
             'localization_id' => ['required', 'integer', 'exists:App\Models\Localization,id'],
+            'timezone' => ['nullable', 'string', 'in:'.implode(',', timezone_identifiers_list(DateTimeZone::ALL))],
         ];
     }
 }

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -24,6 +24,7 @@ class User extends Authenticatable
         'email',
         'password',
         'localization_id',
+        'timezone',
     ];
 
     /**

--- a/laravel/database/migrations/2023_10_07_134527_add_timezone_column_to_users_table.php
+++ b/laravel/database/migrations/2023_10_07_134527_add_timezone_column_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('timezone')->after('localization_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('timezone');
+        });
+    }
+};

--- a/laravel/lang/de/views/instances.php
+++ b/laravel/lang/de/views/instances.php
@@ -30,6 +30,6 @@ return [
     'table_status_stopped' => 'Gestoppt',
     'table_status_stopped_title' => 'Der Bot ist nicht in Betrieb und sammelt daher keine aktuellen Daten.',
     'table_status_running' => 'In Betrieb',
-    'table_status_running_title' => 'Der Bot läuft seit <b>:started_at UTC</b> unter der PID <b>:process_id</b> und sammelt aktuelle Daten.',
+    'table_status_running_title' => 'Der Bot läuft seit <b>:started_at (:timezone)</b> unter der PID <b>:process_id</b> und sammelt aktuelle Daten.',
 
 ];

--- a/laravel/lang/de/views/profile/edit.php
+++ b/laravel/lang/de/views/profile/edit.php
@@ -21,6 +21,10 @@ return [
     'language_label' => 'Sprache',
     'language_help' => 'Deine bevorzugte Sprache.',
 
+    'timezone_label' => 'Zeitzone',
+    'timezone_auto_detect_option' => 'Automatisch erkennen',
+    'timezone_help' => 'Deine bevorzugte Zeitzone.',
+
     'update_profile_button' => 'Profil aktualisieren',
 
     /**
@@ -47,6 +51,7 @@ return [
     'name_validation_error' => 'Bitte gib einen gültigen Namen an!',
     'email_validation_error' => 'Bitte gib eine gültige E-Mail Adresse an!',
     'language_validation_error' => 'Bitte wähle eine verfügbare Sprache aus!',
+    'timezone_validation_error' => 'Bitte wähle eine verfügbare Zeitzone aus!',
     'current_password_validation_error' => 'Bitte gib dein aktuelles, gültiges Passwort an!',
     'new_password_validation_error' => 'Bitte gib dein neues gültiges Passwort ein!',
     'confirm_password_validation_error' => 'Bitte wiederhole dein neues Passwort!',

--- a/laravel/lang/en/views/instances.php
+++ b/laravel/lang/en/views/instances.php
@@ -30,6 +30,6 @@ return [
     'table_status_stopped' => 'Stopped',
     'table_status_stopped_title' => 'The bot is not running and thus not collecting any current data.',
     'table_status_running' => 'Running',
-    'table_status_running_title' => 'The bot is running as PID <b>:process_id</b> since <b>:started_at UTC</b> and collecting current data.',
+    'table_status_running_title' => 'The bot is running as PID <b>:process_id</b> since <b>:started_at (:timezone)</b> and collecting current data.',
 
 ];

--- a/laravel/lang/en/views/profile/edit.php
+++ b/laravel/lang/en/views/profile/edit.php
@@ -21,6 +21,10 @@ return [
     'language_label' => 'Language',
     'language_help' => 'Your preferred language.',
 
+    'timezone_label' => 'Timezone',
+    'timezone_auto_detect_option' => 'Detect automatically',
+    'timezone_help' => 'Your preferred timezone.',
+
     'update_profile_button' => 'Update Profile',
 
     /**
@@ -47,6 +51,7 @@ return [
     'name_validation_error' => 'Please provide a valid name!',
     'email_validation_error' => 'Please provide a valid email address!',
     'language_validation_error' => 'Please select an available language!',
+    'timezone_validation_error' => 'Please select an available timezone!',
     'current_password_validation_error' => 'Please provide your current valid password!',
     'new_password_validation_error' => 'Please provide a new valid password!',
     'confirm_password_validation_error' => 'Please repeat your new password!',

--- a/laravel/resources/views/administration/fonts.blade.php
+++ b/laravel/resources/views/administration/fonts.blade.php
@@ -69,7 +69,7 @@
                 @foreach($fonts as $font)
                 <tr>
                     <td>{{ $font->filename }}</td>
-                    <td>{{ $font->updated_at }}</td>
+                    <td>{{ Carbon\Carbon::parse($font->updated_at)->setTimezone(Request::header('X-Timezone')) }}</td>
                     <td>
                         <div class="d-flex">
                             @can('edit fonts')

--- a/laravel/resources/views/administration/users.blade.php
+++ b/laravel/resources/views/administration/users.blade.php
@@ -81,7 +81,7 @@
                         @endforeach
                     </td>
                     <td class="col-lg-2">
-                        {{ \Illuminate\Support\Carbon::parse($user->created_at)->format('d.m.Y') }}
+                        {{ Carbon\Carbon::parse($user->created_at)->setTimezone(Request::header('X-Timezone')) }}
                     </td>
                     <td class="col-lg-2">
                         <div class="d-flex">

--- a/laravel/resources/views/banner/configuration.blade.php
+++ b/laravel/resources/views/banner/configuration.blade.php
@@ -133,7 +133,7 @@
                             <div class="accordion-body">
                                 <p class="mt-2">{{ __('views/banner/configuration.disable_at_use_case') }}</p>
                                 <input class="form-control" type="datetime-local" id="validationDisableAt" name="disable_at"
-                                    value="{{ old('disable_at', (isset($banner_template)) ? $banner_template->disable_at : '') }}" aria-label="validationDisableAt">
+                                    value="{{ old('disable_at', (isset($banner_template) and !is_null($banner_template->disable_at)) ? Carbon\Carbon::parse($banner_template->disable_at)->setTimezone(Request::header('X-Timezone')) : '') }}" aria-label="validationDisableAt">
                                 <div class="valid-feedback">{{ __('views/banner/configuration.form_validation_looks_good') }}</div>
                                 <div class="invalid-feedback">{{ __('views/banner/configuration.disable_at_validation_error') }}</div>
                                 <div class="form-text">{{ __('views/banner/configuration.disable_at_help') }}</div>
@@ -163,7 +163,7 @@
                                     <div class="col-lg-6">
                                         <label for="validationTimeBasedEnableAt" class="form-label">{{ __('views/banner/configuration.time_based_de_activation_enable_at') }}</label>
                                         <input class="form-control" type="time" id="validationTimeBasedEnableAt" name="time_based_enable_at"
-                                            value="{{ old('time_based_enable_at', (isset($banner_template)) ? $banner_template->time_based_enable_at : '') }}" aria-label="validationTimeBasedEnableAt">
+                                            value="{{ old('time_based_enable_at', (isset($banner_template) and !is_null($banner_template->time_based_enable_at)) ? Carbon\Carbon::parse($banner_template->time_based_enable_at)->setTimezone(Request::header('X-Timezone'))->format('H:i') : '') }}" aria-label="validationTimeBasedEnableAt">
                                         <div class="valid-feedback">{{ __('views/banner/configuration.form_validation_looks_good') }}</div>
                                         <div class="invalid-feedback">{{ __('views/banner/configuration.time_based_de_activation_enable_at_validation_error') }}</div>
                                         <div class="form-text">{{ __('views/banner/configuration.time_based_de_activation_enable_at_help') }}</div>
@@ -172,7 +172,7 @@
                                     <div class="col-lg-6">
                                         <label for="validationTimeBasedDisableAt" class="form-label">{{ __('views/banner/configuration.time_based_de_activation_disable_at') }}</label>
                                         <input class="form-control" type="time" id="validationTimeBasedDisableAt" name="time_based_disable_at"
-                                            value="{{ old('time_based_disable_at', (isset($banner_template)) ? $banner_template->time_based_disable_at : '') }}" aria-label="validationTimeBasedDisableAt">
+                                            value="{{ old('time_based_disable_at', (isset($banner_template) and !is_null($banner_template->time_based_disable_at)) ? Carbon\Carbon::parse($banner_template->time_based_disable_at)->setTimezone(Request::header('X-Timezone'))->format('H:i') : '') }}" aria-label="validationTimeBasedDisableAt">
                                         <div class="valid-feedback">{{ __('views/banner/configuration.form_validation_looks_good') }}</div>
                                         <div class="invalid-feedback">{{ __('views/banner/configuration.time_based_de_activation_disable_at_validation_error') }}</div>
                                         <div class="form-text">{{ __('views/banner/configuration.time_based_de_activation_disable_at_help') }}</div>

--- a/laravel/resources/views/instances.blade.php
+++ b/laravel/resources/views/instances.blade.php
@@ -81,7 +81,11 @@
                             </span>
                         @else
                             <span class="badge text-bg-success" data-bs-toggle="tooltip" data-bs-html="true"
-                                title="{!! __('views/instances.table_status_running_title', ['process_id' => $instance->process->process_id, 'started_at' => $instance->process->created_at]) !!}"
+                                title="{!! __('views/instances.table_status_running_title', [
+                                        'process_id' => $instance->process->process_id,
+                                        'started_at' => Carbon\Carbon::parse($instance->process->created_at)->setTimezone(Request::header('X-Timezone')),
+                                        'timezone' => Request::header('X-Timezone'),
+                                    ]) !!}"
                                 id="status-badge-running">{{ __('views/instances.table_status_running') }}
                             </span>
                         @endif

--- a/laravel/resources/views/layouts/footer-main.blade.php
+++ b/laravel/resources/views/layouts/footer-main.blade.php
@@ -2,7 +2,7 @@
     <footer class="d-flex flex-wrap justify-content-between align-items-center py-3 my-4 border-top">
         <div class="col-md-12 d-flex align-items-center justify-content-between">
             <span class="text-muted">
-                &copy; {{\Illuminate\Support\Carbon::now()->format('Y')}} <a href="https://github.com/Sebbo94BY" target="_blank">Sebbo94BY</a>,
+                &copy; {{ Carbon\Carbon::now(Request::header('X-Timezone'))->format('Y')}} <a href="https://github.com/Sebbo94BY" target="_blank">Sebbo94BY</a>,
                 <a href="https://github.com/Sebbo94BY/teamspeak-dynamic-banner/graphs/contributors" target="_blank">{{ __("views/layouts/footer-main.contributors") }}</a> |
                 {{ __("views/layouts/footer-main.powered_by") }}
                 <span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="HTML5"><i class="fa-brands fa-html5 text-primary fa-xl me-1"></i></span>

--- a/laravel/resources/views/layouts/nav-main.blade.php
+++ b/laravel/resources/views/layouts/nav-main.blade.php
@@ -100,7 +100,7 @@
                     <a class="nav-link dropdown-toggle
                        {{ (str_starts_with(Route::currentRouteName(), 'profile.')) ? 'active' : '' }}"
                        href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                        {!! trans_choice("views/layouts/nav-main.greet_user", Carbon\Carbon::now()->format('H'), ['username' => Auth::user()->name]) !!}
+                        {!! trans_choice("views/layouts/nav-main.greet_user", Carbon\Carbon::now(Request::header('X-Timezone'))->format('H'), ['username' => Auth::user()->name]) !!}
                     </a>
                     <ul class="dropdown-menu">
                         <li><a class="dropdown-item {{ (Route::currentRouteName() == 'profile.edit') ? 'active' : '' }}" href="{{ route('profile.edit') }}">{{ __("views/layouts/nav-main.profile") }}</a></li>

--- a/laravel/resources/views/profile/edit.blade.php
+++ b/laravel/resources/views/profile/edit.blade.php
@@ -52,6 +52,22 @@
                         <div class="valid-feedback">{{ __('views/profile/edit.form_validation_looks_good') }}</div>
                         <div class="invalid-feedback">{{ __('views/profile/edit.language_validation_error') }}</div>
                     </div>
+                    <div class="mb-2">
+                        <label for="validationTimezone" class="form-label fw-bold">{{ __('views/profile/edit.timezone_label') }}</label>
+                        <select class="form-select" name="timezone" id="validationTimezone" aria-describedby="timezoneHelp" required>
+                            <option value="null" @if (is_null($user->timezone)) selected @endif>{{ __('views/profile/edit.timezone_auto_detect_option') }}</option>
+                            @foreach (timezone_identifiers_list(DateTimeZone::ALL) as $timezone)
+                            @if (old('timezone', $user->timezone) == $timezone)
+                            <option value="{{ $timezone }}" selected>{{ $timezone }}</option>
+                            @else
+                            <option value="{{ $timezone }}">{{ $timezone }}</option>
+                            @endif
+                            @endforeach
+                        </select>
+                        <div id="timezoneHelp" class="form-text">{{ __('views/profile/edit.timezone_help') }}</div>
+                        <div class="valid-feedback">{{ __('views/profile/edit.form_validation_looks_good') }}</div>
+                        <div class="invalid-feedback">{{ __('views/profile/edit.timezone_validation_error') }}</div>
+                    </div>
                 </div>
                 <div class="card-footer bg-transparent border-0">
                     <button class="btn btn-primary" type="submit">{{ __('views/profile/edit.update_profile_button') }}</button>

--- a/laravel/resources/views/templates.blade.php
+++ b/laravel/resources/views/templates.blade.php
@@ -77,7 +77,7 @@
                         <p>{{ __('views/templates.table_alias') }}: <b>{{ $template->alias }}</b></p>
                         <p>{{ __('views/templates.table_file_size') }}: {{ ceil(filesize($template->file_path_original.'/'.$template->filename) / 1024) }} KiB</p>
                         <p>{{ __('views/templates.table_file_dimensions') }}: {{ $template->width }}x{{ $template->height }} Pixel</p>
-                        <p>{{ __('views/templates.table_last_modified') }}: {{ date('d.m.Y', strtotime($template->updated_at)) }}</p>
+                        <p>{{ __('views/templates.table_last_modified') }}: {{ Carbon\Carbon::parse($template->updated_at)->setTimezone(Request::header('X-Timezone')) }}</p>
                     </td>
                     <td class="col-lg-2">
                         @can('edit templates')

--- a/laravel/tests/Feature/WebAuthRouteTest.php
+++ b/laravel/tests/Feature/WebAuthRouteTest.php
@@ -2,11 +2,22 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Tests\TestCase;
 
 class WebAuthRouteTest extends TestCase
 {
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Run the DatabaseSeeder
+        $this->seed();
+    }
+
     public function test_login_route_exists()
     {
         $response = $this->get('/login');


### PR DESCRIPTION
The application automatically determines the clients timezone based on which preferred language the browser sends. This timezone is then automatically applied to the UI, so that it shows timestamps in the respective timezone.

If the timezone could not be determined by the application, it will fallback to the default application timezone, which is set in `config/app.php` (`timezone`).

On the profile page, the user can also enforce (set) a specific timezone:

![image](https://github.com/Sebbo94BY/teamspeak-dynamic-banner/assets/5154682/4300ee73-e05e-4966-b4c8-0cfe98eb3620)

Todo:
- [x] Add timezone option to users profile to enforce a specific timezone, if required (e. g. due to VPN)
- [x] Test that all timestamps get respectively converted to the expected timezone

Closes #172