### PR TITLE
Catch TeamSpeak connection exceptions on instance page

### DIFF
--- a/laravel/app/Http/Controllers/InstanceController.php
+++ b/laravel/app/Http/Controllers/InstanceController.php
@@ -33,9 +33,9 @@ class InstanceController extends Controller
                 $virtualserver = $virtualserver_helper->get_virtualserver_connection();
                 $channel_list = $virtualserver->channelList();
                 $channelListForEachInstance[$instance->id]['channel_list'] = $channel_list;
-            } catch (ServerQueryException $serverquery_exception) {
+            } catch (TransportException | ServerQueryException $teamspeak_exception) {
                 $channelListForEachInstance[$instance->id]['channel_list'] = [];
-                $channelListForEachInstance[$instance->id]['error'] = $serverquery_exception->getMessage();
+                $channelListForEachInstance[$instance->id]['error'] = $teamspeak_exception->getMessage();
             }
         }
 


### PR DESCRIPTION
To avoid HTTP 500 errors and/or horrible exception traces, we will also catch here connection exceptions and rather print those in a specified area. This also ensures, that the page is accessible in case of unreachable TeamSpeak instances.