### PR TITLE
Catch generic exceptions on instance page

### DIFF
--- a/laravel/app/Http/Controllers/InstanceController.php
+++ b/laravel/app/Http/Controllers/InstanceController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\InstanceStartRequest;
 use App\Http\Requests\InstanceStopRequest;
 use App\Http\Requests\InstanceUpdateRequest;
 use App\Models\Instance;
+use Exception;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Redirect;
@@ -33,7 +34,7 @@ class InstanceController extends Controller
                 $virtualserver = $virtualserver_helper->get_virtualserver_connection();
                 $channel_list = $virtualserver->channelList();
                 $channelListForEachInstance[$instance->id]['channel_list'] = $channel_list;
-            } catch (TransportException | ServerQueryException $teamspeak_exception) {
+            } catch (TransportException | ServerQueryException | Exception $teamspeak_exception) {
                 $channelListForEachInstance[$instance->id]['channel_list'] = [];
                 $channelListForEachInstance[$instance->id]['error'] = $teamspeak_exception->getMessage();
             }


### PR DESCRIPTION
To avoid HTTP 500 errors and/or horrible exception traces, we will also catch here generic exceptions and rather print those in a specified area. This also ensures, that the page is accessible in case of unreachable TeamSpeak instances.