### PR TITLE
Issue #178: Add twitch integration

### DIFF
--- a/laravel/app/Console/Commands/Banners/TwitchBasedDisabling.php
+++ b/laravel/app/Console/Commands/Banners/TwitchBasedDisabling.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Console\Commands\Banners;
+
+use App\Models\BannerTemplate;
+use App\Models\TwitchApi;
+use Illuminate\Console\Command;
+
+class TwitchBasedDisabling extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'banners:twitch-based-disabling';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Disables templates of all banners, when the configured Twitch streamer is offline.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if (is_null(TwitchApi::first())) {
+            return $this->info('No twitch API has been configured yet. Skipping.');
+        }
+
+        $banner_templates_with_set_twitch_streamer = BannerTemplate::whereNotNull('twitch_streamer_id')->get(['id', 'twitch_streamer_id', 'enabled']);
+
+        $this->info('Checking '.count($banner_templates_with_set_twitch_streamer).' banner templates...');
+
+        foreach ($banner_templates_with_set_twitch_streamer as $banner_template) {
+            if (! $banner_template->enabled) {
+                $this->info("The banner template with the ID $banner_template->id is already disabled. Skipping.");
+                continue;
+            }
+
+            if ($banner_template->twitch_streamer->is_live) {
+                $this->info("The banner template with the ID $banner_template->id should NOT be disabled yet. Skipping.");
+                continue;
+            }
+
+            $banner_template->enabled = false;
+
+            if (! $banner_template->save()) {
+                $this->error("Failed to disable the banner template with the ID $banner_template->id. See ".route('banner.template.configuration.edit', ['banner_template_id' => $banner_template->id]).' for details.');
+            }
+
+            $this->warn("Successfully disabled the banner template with the ID $banner_template->id. See ".route('banner.template.configuration.edit', ['banner_template_id' => $banner_template->id]).' for details.');
+        }
+    }
+}

--- a/laravel/app/Console/Commands/Banners/TwitchBasedEnabling.php
+++ b/laravel/app/Console/Commands/Banners/TwitchBasedEnabling.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Console\Commands\Banners;
+
+use App\Models\BannerTemplate;
+use App\Models\TwitchApi;
+use Illuminate\Console\Command;
+
+class TwitchBasedEnabling extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'banners:twitch-based-enabling';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Enables templates of all banners, when the configured Twitch streamer is online.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if (is_null(TwitchApi::first())) {
+            return $this->info('No twitch API has been configured yet. Skipping.');
+        }
+
+        $banner_templates_with_set_twitch_streamer = BannerTemplate::whereNotNull('twitch_streamer_id')->get(['id', 'twitch_streamer_id', 'enabled']);
+
+        $this->info('Checking '.count($banner_templates_with_set_twitch_streamer).' banner templates...');
+
+        foreach ($banner_templates_with_set_twitch_streamer as $banner_template) {
+            if ($banner_template->enabled) {
+                $this->info("The banner template with the ID $banner_template->id is already enabled. Skipping.");
+                continue;
+            }
+
+            if (! $banner_template->twitch_streamer->is_live) {
+                $this->info("The banner template with the ID $banner_template->id should NOT be enabled yet. Skipping.");
+                continue;
+            }
+
+            $banner_template->enabled = true;
+
+            if (! $banner_template->save()) {
+                $this->error("Failed to enable the banner template with the ID $banner_template->id. See ".route('banner.template.configuration.edit', ['banner_template_id' => $banner_template->id]).' for details.');
+            }
+
+            $this->warn("Successfully enabled the banner template with the ID $banner_template->id. See ".route('banner.template.configuration.edit', ['banner_template_id' => $banner_template->id]).' for details.');
+        }
+    }
+}

--- a/laravel/app/Console/Commands/Twitch/UpdateApiAccessToken.php
+++ b/laravel/app/Console/Commands/Twitch/UpdateApiAccessToken.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands\Twitch;
+
+use App\Models\TwitchApi;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+
+class UpdateApiAccessToken extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'twitch:update-api-access-token';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Performs a Twitch API authentication and updates the access token in the database.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $twitch_api = TwitchApi::first();
+
+        if (is_null($twitch_api)) {
+            return $this->info('No twitch API has been configured yet. Skipping.');
+        }
+
+        if (! is_null($twitch_api->access_token) and Carbon::now()->addMinutes(30)->lt($twitch_api->expires_at)) {
+            return $this->info('The existing access token is still valid for at least the next 30 minutes. Skipping.');
+        }
+
+        $this->info('Performing a Twitch API authentication...');
+
+        $twitch_api_response = Http::post('https://id.twitch.tv/oauth2/token?client_id='.$twitch_api->client_id.'&client_secret='.$twitch_api->client_secret.'&grant_type=client_credentials');
+
+        if ($twitch_api_response->failed()) {
+            return $this->error('The Twitch API authentication request failed due to the following error: '.json_encode($twitch_api_response->json()));
+        }
+
+        $twitch_api_response_json = $twitch_api_response->json();
+
+        $twitch_api->access_token = $twitch_api_response_json['access_token'];
+        $twitch_api->expires_at = Carbon::now()->addSeconds($twitch_api_response_json['expires_in']);
+
+        if (! $twitch_api->save()) {
+            return $this->error('Failed to update the access token and expiry date in the database.');
+        }
+
+        $this->info('Successfully updated the access token and expiry date in the database.');
+    }
+}

--- a/laravel/app/Console/Commands/Twitch/UpdateStreamerInformation.php
+++ b/laravel/app/Console/Commands/Twitch/UpdateStreamerInformation.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Console\Commands\Twitch;
+
+use App\Models\TwitchApi;
+use App\Models\TwitchStreamer;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+
+class UpdateStreamerInformation extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'twitch:update-streamer-information';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Retrieves current Twitch stream information and updates those in the system.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $twitch_api = TwitchApi::first();
+
+        if (is_null($twitch_api)) {
+            return $this->info('No Twitch API credentials have been provided yet. Doing nothing.');
+        }
+
+        $twitch_streamer = TwitchStreamer::all();
+
+        $this->info('Retrieving current Twitch stream information for '.$twitch_streamer->count().' streams...');
+
+        foreach ($twitch_streamer as $streamer) {
+            $streamer_login = str_replace('https://www.twitch.tv/', '', $streamer->stream_url);
+
+            $twitch_api_users_response = Http::withHeaders([
+                'Client-Id' => $twitch_api->client_id,
+            ])->withToken($twitch_api->access_token)->get("https://api.twitch.tv/helix/users?login=$streamer_login");
+
+            if ($twitch_api_users_response->failed()) {
+                $this->warn('The Twitch API request failed due to the following error: '.json_encode($twitch_api_users_response->json()));
+                continue;
+            }
+
+            $twitch_api_users_response_json = $twitch_api_users_response->json();
+
+            if (count($twitch_api_users_response_json['data']) == 0) {
+                $this->info('Could not find any Twitch streamer with the stream URL '.$streamer->stream_url.'.');
+
+                $streamer->is_live = false;
+                $streamer->started_at = null;
+                $streamer->game_name = null;
+                $streamer->title = null;
+                $streamer->viewer_count = 0;
+                $streamer->save();
+
+                continue;
+            }
+
+            $twitch_api_streams_response = Http::withHeaders([
+                'Client-Id' => $twitch_api->client_id,
+            ])->withToken($twitch_api->access_token)->get('https://api.twitch.tv/helix/streams?user_id='.reset($twitch_api_users_response_json['data'])['id']);
+
+            $twitch_api_streams_response_json = $twitch_api_streams_response->json();
+
+            if (count($twitch_api_streams_response_json['data']) == 0 or (reset($twitch_api_streams_response_json['data'])['type'] != 'live')) {
+                $this->info('The Twitch streamer '.$streamer->stream_url.' is currently offline.');
+
+                $streamer->is_live = false;
+                $streamer->save();
+
+                continue;
+            }
+
+            $this->info('The Twitch streamer '.$streamer->stream_url.' is currently online.');
+
+            $twitch_api_streams_response_json = reset($twitch_api_streams_response_json['data']);
+
+            $streamer->is_live = true;
+            $streamer->started_at = Carbon::parse($twitch_api_streams_response_json['started_at'])->setTimezone(config('app.timezone'));
+            $streamer->game_name = $twitch_api_streams_response_json['game_name'];
+            $streamer->title = $twitch_api_streams_response_json['title'];
+            $streamer->viewer_count = intval($twitch_api_streams_response_json['viewer_count']);
+            $streamer->save();
+        }
+    }
+}

--- a/laravel/app/Console/Kernel.php
+++ b/laravel/app/Console/Kernel.php
@@ -71,6 +71,26 @@ class Kernel extends ConsoleKernel
         $schedule->call(function () {
             Process::start('php '.base_path().'/artisan banners:disable-time-based');
         })->name('banners:disable-time-based')->everyFiveMinutes();
+
+        // BANNERS: Twitch-based Enabling
+        $schedule->call(function () {
+            Process::start('php '.base_path().'/artisan banners:twitch-based-enabling');
+        })->name('banners:twitch-based-enabling')->everyFiveMinutes();
+
+        // BANNERS: Twitch-based Disabling
+        $schedule->call(function () {
+            Process::start('php '.base_path().'/artisan banners:twitch-based-disabling');
+        })->name('banners:twitch-based-disabling')->everyFiveMinutes();
+
+        // TWITCH: Update API Access Token
+        $schedule->call(function () {
+            Process::start('php '.base_path().'/artisan twitch:update-api-access-token');
+        })->name('twitch:update-api-access-token')->everyFiveMinutes();
+
+        // TWITCH: Update Streamer information
+        $schedule->call(function () {
+            Process::start('php '.base_path().'/artisan twitch:update-streamer-information');
+        })->name('twitch:update-streamer-information')->everyMinute();
     }
 
     /**

--- a/laravel/app/Http/Controllers/Administration/TwitchController.php
+++ b/laravel/app/Http/Controllers/Administration/TwitchController.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Http\Controllers\Administration;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\TwitchApiCredentialsUpdateRequest;
+use App\Http\Requests\TwitchStreamerAddRequest;
+use App\Http\Requests\TwitchStreamerDeleteRequest;
+use App\Http\Requests\TwitchStreamerUpdateRequest;
+use App\Models\TwitchApi;
+use App\Models\TwitchStreamer;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\View\View;
+
+class TwitchController extends Controller
+{
+    /**
+     * Display the view.
+     */
+    public function view(): View
+    {
+        return view('administration.twitch')->with([
+            'twitch_api' => TwitchApi::first(),
+            'twitch_streamer' => TwitchStreamer::all(),
+        ]);
+    }
+
+    /**
+     * Updates the Twitch API credentials in the database.
+     */
+    public function update_api_credentials(TwitchApiCredentialsUpdateRequest $request): RedirectResponse
+    {
+        $twitch_api_response = Http::post('https://id.twitch.tv/oauth2/token?client_id='.$request->validated('client_id').'&client_secret='.$request->validated('client_secret').'&grant_type=client_credentials');
+
+        if ($twitch_api_response->failed()) {
+            return Redirect::route('administration.twitch')
+                ->withInput($request->all())
+                ->with([
+                    'error' => 'twitch-api-credentials-update-error',
+                    'message' => 'Failed to get an access token with the provided Twitch API credentials. Please double-check the API credentials! API Response: '.json_encode($twitch_api_response->json()),
+                ]);
+        }
+
+        $twitch_api = TwitchApi::firstOrCreate();
+
+        $twitch_api->client_id = $request->validated('client_id');
+        $twitch_api->client_secret = $request->validated('client_secret');
+
+        $twitch_api_response_json = $twitch_api_response->json();
+        $twitch_api->access_token = $twitch_api_response_json['access_token'];
+        $twitch_api->expires_at = Carbon::now()->addSeconds($twitch_api_response_json['expires_in']);
+
+        if (! $twitch_api->save()) {
+            return Redirect::route('administration.twitch')
+                ->withInput($request->all())
+                ->with([
+                    'error' => 'twitch-api-credentials-update-error',
+                    'message' => 'Failed to update the Twitch API credentials in the database. Please try again.',
+                ]);
+        }
+
+        return Redirect::route('administration.twitch')->with([
+            'success' => 'twitch-api-credentials-update-successful',
+            'message' => 'Successfully updated the Twitch API credentials.',
+        ]);
+    }
+
+    /**
+     * Deletes the Twitch API credentials from the database.
+     */
+    public function delete_api_credentials(): RedirectResponse
+    {
+        $twitch_api = TwitchApi::first();
+
+        if (! $twitch_api->delete()) {
+            return Redirect::route('administration.twitch')
+                ->with([
+                    'error' => 'twitch-api-credentials-delete-error',
+                    'message' => 'Failed to delete the Twitch API credentials from the database. Please try again.',
+                ]);
+        }
+
+        return Redirect::route('administration.twitch')->with([
+            'success' => 'twitch-api-credentials-delete-successful',
+            'message' => 'Successfully deleted the Twitch API credentials.',
+        ]);
+    }
+
+    /**
+     * Adds a new Twitch streamer URL to the system.
+     */
+    public function create_streamer(TwitchStreamerAddRequest $request): RedirectResponse
+    {
+        $twitch_streamer = new TwitchStreamer();
+        $twitch_streamer->stream_url = $request->validated('stream_url');
+
+        if (! $twitch_streamer->save()) {
+            return Redirect::route('administration.twitch')->withInput($request->all())->with([
+                'error' => 'twitch-streamer-add-error',
+                'message' => 'Failed to add the new Twitch streamer to the database. Please try again.',
+            ]);
+        }
+
+        return Redirect::route('administration.twitch')->with([
+            'success' => 'twitch-streamer-add-successful',
+            'message' => 'Successfully added the new Twitch streamer.',
+        ]);
+    }
+
+    /**
+     * Updates an existing Twitch streamer URL in the system.
+     */
+    public function update_streamer(TwitchStreamerUpdateRequest $request): RedirectResponse
+    {
+        $twitch_streamer = TwitchStreamer::find($request->validated('twitch_streamer_id'));
+        $twitch_streamer->stream_url = $request->validated('stream_url');
+
+        if (! $twitch_streamer->save()) {
+            return Redirect::route('administration.twitch')->withInput($request->all())->with([
+                'error' => 'twitch-streamer-update-error',
+                'message' => 'Failed to update the existing Twitch streamer in the database. Please try again.',
+            ]);
+        }
+
+        return Redirect::route('administration.twitch')->with([
+            'success' => 'twitch-streamer-update-successful',
+            'message' => 'Successfully updated the Twitch streamer.',
+        ]);
+    }
+
+    /**
+     * Deletes an existing Twitch streamer URL from the system.
+     */
+    public function delete_streamer(TwitchStreamerDeleteRequest $request): RedirectResponse
+    {
+        $twitch_streamer = TwitchStreamer::find($request->validated('twitch_streamer_id'));
+
+        if (! $twitch_streamer->delete()) {
+            return Redirect::route('administration.twitch')->withInput($request->all())->with([
+                'error' => 'twitch-streamer-delete-error',
+                'message' => 'Failed to delete the existing Twitch streamer from the database. Please try again.',
+            ]);
+        }
+
+        return Redirect::route('administration.twitch')->with([
+            'success' => 'twitch-streamer-delete-successful',
+            'message' => 'Successfully deleted the Twitch streamer.',
+        ]);
+    }
+}

--- a/laravel/app/Http/Controllers/BannerVariableController.php
+++ b/laravel/app/Http/Controllers/BannerVariableController.php
@@ -13,12 +13,11 @@ class BannerVariableController extends Controller
     /**
      * Display the overview page.
      */
-    public function getInstanceVariables(int $instance_id): array
+    public function getInstanceVariables(Instance $instance): array
     {
-        $instance = Instance::find($instance_id);
-
         $redis_connection_error = null;
         $variables_and_values = [];
+
         try {
             $variables_and_values = array_merge($variables_and_values, Redis::hgetall('instance_'.$instance->id.'_datetime'));
             $variables_and_values = array_merge($variables_and_values, Redis::hgetall('instance_'.$instance->id.'_servergrouplist'));

--- a/laravel/app/Http/Controllers/Helpers/BannerVariableController.php
+++ b/laravel/app/Http/Controllers/Helpers/BannerVariableController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Helpers;
 
 use App\Http\Controllers\Controller;
 use App\Models\Instance;
+use App\Models\TwitchApi;
+use App\Models\TwitchStreamer;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Redis;
 use PlanetTeamSpeak\TeamSpeak3Framework\Exception\ServerQueryException;
@@ -184,5 +186,25 @@ class BannerVariableController extends Controller
         }
 
         return array_change_key_case($client_info, CASE_UPPER);
+    }
+
+    /**
+     * Get Twitch streamer information.
+     */
+    public function get_twitch_streamer_information_from_database(?TwitchStreamer $twitch_streamer = null): array
+    {
+        $streamer_information = [];
+
+        if (is_null(TwitchApi::first()) or is_null($twitch_streamer)) {
+            return $streamer_information;
+        }
+
+        $streamer_information['twitch_stream_status'] = ($twitch_streamer['is_live']) ? 'LIVE' : 'Offline';
+        $streamer_information['twitch_stream_live_since'] = Carbon::parse($twitch_streamer['started_at'])->diffAsCarbonInterval();
+        $streamer_information['twitch_stream_game_name'] = $twitch_streamer['game_name'];
+        $streamer_information['twitch_stream_title'] = $twitch_streamer['title'];
+        $streamer_information['twitch_stream_viewer_count'] = $twitch_streamer['viewer_count'];
+
+        return array_change_key_case($streamer_information, CASE_UPPER);
     }
 }

--- a/laravel/app/Http/Controllers/Helpers/DrawTextOnTemplateController.php
+++ b/laravel/app/Http/Controllers/Helpers/DrawTextOnTemplateController.php
@@ -132,6 +132,7 @@ class DrawTextOnTemplateController extends Controller
 
         $banner_variable_helper = new BannerVariableController(null);
         $variables_and_values = array_merge($variables_and_values, $banner_variable_helper->get_client_specific_info_from_cache($banner_template->banner->instance, $ip_address));
+        $variables_and_values = array_merge($variables_and_values, $banner_variable_helper->get_twitch_streamer_information_from_database($banner_template->twitch_streamer));
 
         foreach ($files_to_update as $source_path => $target_path) {
             // Permanently or temporary write it to the storage

--- a/laravel/app/Http/Requests/TwitchApiCredentialsUpdateRequest.php
+++ b/laravel/app/Http/Requests/TwitchApiCredentialsUpdateRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TwitchApiCredentialsUpdateRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'client_id' => ['required', 'string', 'max:255'],
+            'client_secret' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/laravel/app/Http/Requests/TwitchStreamerAddRequest.php
+++ b/laravel/app/Http/Requests/TwitchStreamerAddRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TwitchStreamerAddRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'stream_url' => ['required', 'url:https', 'starts_with:https://www.twitch.tv/'],
+        ];
+    }
+}

--- a/laravel/app/Http/Requests/TwitchStreamerDeleteRequest.php
+++ b/laravel/app/Http/Requests/TwitchStreamerDeleteRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TwitchStreamerDeleteRequest extends FormRequest
+{
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'twitch_streamer_id' => $this->route('twitch_streamer_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'twitch_streamer_id' => ['required', 'integer', 'exists:App\Models\TwitchStreamer,id'],
+        ];
+    }
+}

--- a/laravel/app/Http/Requests/TwitchStreamerUpdateRequest.php
+++ b/laravel/app/Http/Requests/TwitchStreamerUpdateRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TwitchStreamerUpdateRequest extends FormRequest
+{
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'twitch_streamer_id' => $this->route('twitch_streamer_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'twitch_streamer_id' => ['required', 'integer', 'exists:App\Models\TwitchStreamer,id'],
+            'stream_url' => ['required', 'url:https', 'starts_with:https://www.twitch.tv/'],
+        ];
+    }
+}

--- a/laravel/app/Models/BannerTemplate.php
+++ b/laravel/app/Models/BannerTemplate.php
@@ -26,6 +26,7 @@ class BannerTemplate extends Model
         'disable_at',
         'time_based_enable_at',
         'time_based_disable_at',
+        'twitch_streamer_id',
         'enabled',
     ];
 
@@ -60,6 +61,14 @@ class BannerTemplate extends Model
     public function template(): BelongsTo
     {
         return $this->belongsTo(Template::class);
+    }
+
+    /**
+     * Get the Twitch streamer associated with the model.
+     */
+    public function twitch_streamer(): BelongsTo
+    {
+        return $this->belongsTo(TwitchStreamer::class);
     }
 
     /**

--- a/laravel/app/Models/Instance.php
+++ b/laravel/app/Models/Instance.php
@@ -64,6 +64,6 @@ class Instance extends Model
     {
         $varController = new BannerVariableController();
 
-        return $varController->getInstanceVariables($this->id);
+        return $varController->getInstanceVariables($this);
     }
 }

--- a/laravel/app/Models/TwitchApi.php
+++ b/laravel/app/Models/TwitchApi.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TwitchApi extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'client_id',
+        'client_secret',
+        'access_token',
+        'expires_at',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'client_secret',
+        'access_token',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'client_secret' => 'encrypted',
+        'access_token' => 'encrypted',
+        'expires_at' => 'datetime',
+    ];
+}

--- a/laravel/app/Models/TwitchStreamer.php
+++ b/laravel/app/Models/TwitchStreamer.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TwitchStreamer extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'stream_url',
+        'is_live',
+        'started_at',
+        'game_name',
+        'title',
+        'viewer_count',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'is_live' => 'boolean',
+        'started_at' => 'datetime',
+    ];
+}

--- a/laravel/database/factories/TwitchApiFactory.php
+++ b/laravel/database/factories/TwitchApiFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<\App\Models\User>
+ */
+class TwitchApiFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'client_id' => Str::random(32),
+            'client_secret' => Str::random(32),
+            'access_token' => Str::random(32),
+            'expires_at' => fake()->dateTime(Carbon::now()->addDays(30)),
+        ];
+    }
+}

--- a/laravel/database/factories/TwitchStreamerFactory.php
+++ b/laravel/database/factories/TwitchStreamerFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<\App\Models\User>
+ */
+class TwitchStreamerFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'stream_url' => 'https://www.twitch.tv/'.Str::random(32),
+            'is_live' => fake()->boolean(),
+            'started_at' => fake()->dateTime(Carbon::now()->subMinutes(30)),
+            'game_name' => fake()->name(),
+            'title' => fake()->text(192),
+            'viewer_count' => fake()->numberBetween(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2023_10_08_121556_create_twitch_streamers_table.php
+++ b/laravel/database/migrations/2023_10_08_121556_create_twitch_streamers_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('twitch_streamers', function (Blueprint $table) {
+            $table->id();
+            $table->string('stream_url');
+            $table->boolean('is_live')->default(false);
+            $table->timestamp('started_at')->nullable();
+            $table->string('game_name')->nullable();
+            $table->string('title')->nullable();
+            $table->integer('viewer_count')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('twitch_streamers');
+    }
+};

--- a/laravel/database/migrations/2023_10_08_124612_create_twitch_apis_table.php
+++ b/laravel/database/migrations/2023_10_08_124612_create_twitch_apis_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('twitch_apis', function (Blueprint $table) {
+            $table->id();
+            $table->string('client_id')->nullable();
+            $table->text('client_secret')->nullable();
+            $table->text('access_token')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('twitch_apis');
+    }
+};

--- a/laravel/database/migrations/2023_10_10_202218_add_twitch_streamer_id_column_to_banner_templates.php
+++ b/laravel/database/migrations/2023_10_10_202218_add_twitch_streamer_id_column_to_banner_templates.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('banner_templates', function (Blueprint $table) {
+            $table->foreignId('twitch_streamer_id')->after('time_based_disable_at')->nullable()->constrained()->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('banner_templates', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('twitch_streamer_id');
+        });
+    }
+};

--- a/laravel/database/seeders/PermissionSeeder.php
+++ b/laravel/database/seeders/PermissionSeeder.php
@@ -33,6 +33,14 @@ class PermissionSeeder extends Seeder
         Permission::firstOrCreate(['name' => 'edit fonts']);
         Permission::firstOrCreate(['name' => 'delete fonts']);
 
+        // Administration: Twitch
+        Permission::firstOrCreate(['name' => 'view twitch']);
+        Permission::firstOrCreate(['name' => 'edit twitch api credentials']);
+        Permission::firstOrCreate(['name' => 'delete twitch api credentials']);
+        Permission::firstOrCreate(['name' => 'add twitch streamers']);
+        Permission::firstOrCreate(['name' => 'edit twitch streamers']);
+        Permission::firstOrCreate(['name' => 'delete twitch streamers']);
+
         // Administration: System Status
         Permission::firstOrCreate(['name' => 'view system status']);
 

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -53,6 +53,37 @@ class RoleSeeder extends Seeder
             'delete fonts',
         ]);
 
+        // Administration: Twitch
+        $twitch_super_admin = Role::firstOrCreate(['name' => 'Twitch Super Admin']);
+        $twitch_super_admin->syncPermissions([
+            'view twitch',
+            'edit twitch api credentials',
+            'delete twitch api credentials',
+            'add twitch streamers',
+            'edit twitch streamers',
+            'delete twitch streamers',
+        ]);
+
+        $twitch_api_admin = Role::firstOrCreate(['name' => 'Twitch API Admin']);
+        $twitch_api_admin->syncPermissions([
+            'view twitch',
+            'edit twitch api credentials',
+            'delete twitch api credentials',
+        ]);
+
+        $twitch_streamer_admin = Role::firstOrCreate(['name' => 'Twitch Streamer Admin']);
+        $twitch_streamer_admin->syncPermissions([
+            'view twitch',
+            'add twitch streamers',
+            'edit twitch streamers',
+            'delete twitch streamers',
+        ]);
+
+        $twitch_viewer = Role::firstOrCreate(['name' => 'Twitch Viewer']);
+        $twitch_viewer->syncPermissions([
+            'view twitch',
+        ]);
+
         // Administration: System Status
         $system_status_viewer = Role::firstOrCreate(['name' => 'System Status Viewer']);
         $system_status_viewer->syncPermissions([

--- a/laravel/lang/de/views/administration/twitch.php
+++ b/laravel/lang/de/views/administration/twitch.php
@@ -1,0 +1,74 @@
+<?php
+
+return [
+
+    /**
+     * Twitch Headline
+     */
+    'twitch' => 'Twitch',
+
+    /**
+     * Accordion
+     */
+    'api_credentials_accordion_headline' => 'Twitch API Zugangsdaten',
+
+    'api_credentials_accordion_unconfigured' => 'Unkonfiguriert',
+    'api_credentials_accordion_invalid_credentials' => 'Ungültige Zugangsdaten',
+    'api_credentials_accordion_valid_credentials' => 'Gültige Zugangsdaten',
+
+    'api_usage_information' => 'Um diese Integration nutzen zu können, musst du diese Anwendung als Anwendung bei Twitch registrieren, damit du API-Zugangsdaten erhältst.',
+    'twitch_register_app_documentation' => 'Hier findest du die ausführliche offizielle Dokumentation: <a href="https://dev.twitch.tv/docs/authentication/register-app">https://dev.twitch.tv/docs/authentication/register-app</a>',
+    'installation_instructions' => 'Kurzanleitung',
+    'step_login_or_create_twitch_account' => 'Melde dich bei deinem Twitch-Konto an oder erstelle ein neues, falls du noch keins hast.',
+    'step_open_twitch_dev_console' => 'Öffne <a href="https://dev.twitch.tv/console">https://dev.twitch.tv/console</a>',
+    'step_open_applications' => 'Klicke auf <b>Anwendungen</b>',
+    'step_open_register_app' => 'Klicke auf <b>Deine Anwendung registrieren</b>',
+    'step_fill_out_the_form' => 'Fülle das Formular aus',
+    'step_fill_out_the_form_name' => '<b>Name</b>: <code>teamspeak-dynamischer-banner</code> (nur ein Beispiel; benutze jeden Namen, den du willst - er ist nur auf dieser Twitch-Seite sichtbar)',
+    'step_fill_out_the_form_oauth_redirect_urls' => '<b>OAuth Redirect URLs</b>: <code>http://localhost</code> (nicht relevant, also setze dies einfach zum Beispiel)',
+    'step_fill_out_the_form_category' => '<b>Kategorie</b>: <code>Website Integration</code>',
+    'step_open_new_app' => 'Klicke auf <b>Verwalten</b> neben deiner neuen Anwendung',
+    'step_copy_and_insert_client_id' => 'Afterwards, you will see the <code>Client-ID</code> of your application. Insert this value into the <b>Client ID</b> field here.',
+    'step_copy_and_insert_client_secret' => 'Klicke auf <b>Neues Geheimnis</b>. Du wirst temporär das <code>Client-Geheimnis</code> deiner Anwendung sehen. Füge diesen Wert in das <b>Client Geheimnis</b> Feld hier ein.',
+    'step_submit_form' => 'Sende das Formular ab',
+
+    'api_client_id' => 'Client ID',
+    'api_client_id_placeholder' => 'z.B. 1ec8e09a145fc972b5eed9d1deb51631',
+    'api_client_id_help' => 'Die Client ID deiner Twitch API Zugangsdaten.',
+
+    'api_client_secret' => 'Client Geheimnis',
+    'api_client_secret_placeholder' => 'z.B. ca733c04c302365cc782283ed5b7d39a',
+    'api_client_secret_help' => 'Das Client Geheimnis deiner Twitch API Zugangsdaten.',
+
+    /**
+     * Buttons
+     */
+    'save_button' => 'Speichern',
+    'delete_api_credentials_button' => 'API Zugangsdaten löschen',
+    'add_streamer_button' => 'Twitch Streamer hinzufügen',
+
+    /**
+     * Information Box
+     */
+    'no_permissions_to_edit_the_api_credentials' => 'Du hast keine Berechtigungen, die API Zugangsdaten einzusehen und zu ändern. Bitte wende dich an einen Admin.',
+    'no_streamer_added_info' => 'Bisher wurde noch kein Twitch Streamer hinzugefügt.',
+    'no_twitch_api_credentials_are_configured' => 'Diese Integration funktioniert nur, wenn du gültige Twitch API Zugangsdaten konfigurierst. Diese Integration zieht derzeit weder Twitch Stream Informationen, noch aktiviert oder deaktiviert sie deine Bannervorlagen, wenn sie konfiguriert sind.',
+
+    /**
+     * Datatable
+     */
+    'table_stream_status' => 'Status',
+    'table_stream_url' => 'Stream URL',
+    'table_last_modified' => 'Zuletzt geändert',
+
+    'table_stream_status_online' => 'Online',
+    'table_stream_status_offline' => 'Offline',
+
+    /**
+     * Form Validation
+     */
+    'form_validation_looks_good' => 'Sieht gut aus!',
+    'api_client_id_validation_error' => 'Bitte gib eine gültige Client ID an!',
+    'api_client_secret_validation_error' => 'Bitte gib einen gültigen Client Secret an!',
+
+];

--- a/laravel/lang/de/views/banner/configuration.php
+++ b/laravel/lang/de/views/banner/configuration.php
@@ -36,6 +36,7 @@ return [
      */
     'accordion_status_not_configured' => 'Unkonfiguriert',
     'accordion_status_configured' => 'Konfiguriert',
+    'accordion_status_configured_but_ignored' => 'Ignoriert',
     'accordion_status_no_configurations' => 'Keine Konfigurationen',
     'accordion_status_has_configurations' => '{1} :count_configurations Konfiguration|{2,*} :count_configurations Konfigurationen',
 
@@ -56,11 +57,17 @@ return [
     'disable_at_help' => 'Definiere ein optionales Datum und eine Uhrzeit, zu der diese Konfiguration automatisch deaktiviert werden soll. Lass das Feld leer, um sie nicht automatisch zu deaktivieren.',
 
     'time_based_de_activation_accordion_headline' => 'Zeitbasierte Aktivierung/Deaktivierung',
+    'twitch_based_de_activation_no_twitch_api_credentials_are_configured' => 'Diese Integration funktioniert nur, wenn du gültige Twitch API Zugangsdaten konfigurierst. Diese Integration zieht derzeit weder Twitch Stream Informationen, noch aktiviert oder deaktiviert sie deine Bannervorlagen, wenn sie konfiguriert sind.',
     'time_based_de_activation_use_case' => 'Diese Funktion ist zum Beispiel nützlich, wenn du bestimmte Bannerkonfigurationen nur während eines bestimmten Zeitfensters anzeigen möchtest.',
     'time_based_de_activation_enable_at' => 'Aktiviere um',
     'time_based_de_activation_enable_at_help' => 'Lege einen optionalen Zeitpunkt fest, zu dem diese Konfiguration automatisch aktiviert werden soll. Lass diesen Wert ungesetzt, um sie nicht automatisch zu aktivieren.',
     'time_based_de_activation_disable_at' => 'Deaktiviere um',
     'time_based_de_activation_disable_at_help' => 'Lege einen optionalen Zeitpunkt fest, zu dem diese Konfiguration automatisch deaktiviert werden soll. Lass diesen Wert ungesetzt, um sie nicht automatisch zu deaktivieren.',
+
+    'twitch_based_de_activation_accordion_headline' => 'Twitch-basierte Aktivierung/Deaktivierung',
+    'twitch_based_de_activation_use_case' => 'Diese Funktion ist zum Beispiel nützlich, wenn du bestimmte Bannerkonfigurationen nur dann anzeigen möchtest, wenn der jeweilige Twitch Streamer online ist.',
+    'twitch_based_de_activation_twitch_streamer_id' => 'Twitch Streamer',
+    'twitch_based_de_activation_twitch_streamer_id_help' => 'Wähle einen optionalen Twitch Streamer aus, um diese Bannerkonfiguration automatisch zu aktivieren und zu deaktivieren, wenn der Streamer online oder offline ist.',
 
     'text_configurations_accordion_headline' => 'Text Konfigurationen',
 

--- a/laravel/lang/de/views/layouts/nav-main.php
+++ b/laravel/lang/de/views/layouts/nav-main.php
@@ -25,6 +25,7 @@ return [
     'administration_users' => 'Benutzer',
     'administration_roles' => 'Rollen',
     'administration_fonts' => 'Schriftarten',
+    'administration_twitch' => 'Twitch',
     'administration_systemstatus' => 'System Status',
     'administration_phpinfo' => 'PHP Info',
 

--- a/laravel/lang/de/views/modals/delete-feedback/modal-delete-twitch-api-credentials.php
+++ b/laravel/lang/de/views/modals/delete-feedback/modal-delete-twitch-api-credentials.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /**
+     * Modal Headline
+     */
+    'delete_twitch_api_credentials' => 'Twitch API Zugangsdaten löschen',
+
+    /**
+     * Form
+     */
+    'are_you_sure_question' => 'Bist du dir wirklich sicher, dass du die Twitch API Zugangsdaten aus dem System löschen willst?',
+    'not_revertible_hint' => 'Diese Aktion ist nicht rückgängig zu machen.',
+
+    /**
+     * Buttons
+     */
+    'dismiss_button' => 'Abbrechen',
+    'delete_button' => 'Löschen',
+
+];

--- a/laravel/lang/de/views/modals/delete-feedback/modal-delete-twitch.php
+++ b/laravel/lang/de/views/modals/delete-feedback/modal-delete-twitch.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /**
+     * Modal Headline
+     */
+    'delete_twitch_streamer' => 'Twitch Streamer löschen',
+
+    /**
+     * Form
+     */
+    'are_you_sure_question' => 'Bist du dir wirklich sicher, dass du den Twitch Streamer <a href=":stream_url" target="_blank">:stream_url</a> löschen willst?',
+    'relation_deletion_hint' => 'Dadurch wird auch automatisch die automatische Aktivierung/Deaktivierung von allen Bannertext-Konfigurationen entfernt, die diesen Twitch Streamer verwenden.',
+    'not_revertible_hint' => 'Diese Aktion ist nicht rückgängig zu machen.',
+
+    /**
+     * Buttons
+     */
+    'dismiss_button' => 'Abbrechen',
+    'delete_button' => 'Löschen',
+
+];

--- a/laravel/lang/de/views/modals/twitch/modal-add.php
+++ b/laravel/lang/de/views/modals/twitch/modal-add.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+
+    /**
+     * Modal Headline
+     */
+    'add_new_twitch_streamer' => 'Neue Twitch Streamer hinzufügen',
+
+    /**
+     * Form
+     */
+    'stream_url' => 'Stream URL',
+    'stream_url_placeholder' => 'z.B. https://www.twitch.tv/BeispielStreamer',
+    'stream_url_help' => 'Die URL des Twitch Streamers.',
+
+    /**
+     * Buttons
+     */
+    'dismiss_button' => 'Abbrechen',
+    'add_button' => 'Hinzufügen',
+
+    /**
+     * Form Validation
+     */
+    'form_validation_looks_good' => 'Sieht gut aus!',
+    'stream_url_validation_error' => 'Bitte gib eine gültige Twitch Stream URL an!',
+
+];

--- a/laravel/lang/de/views/modals/twitch/modal-edit.php
+++ b/laravel/lang/de/views/modals/twitch/modal-edit.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+
+    /**
+     * Modal Headline
+     */
+    'update_streamer' => 'Twitch Streamer <code>:stream_url</code> aktualisieren',
+
+    /**
+     * Form
+     */
+    'stream_url' => 'Stream URL',
+    'stream_url_placeholder' => 'z.B. https://www.twitch.tv/BeispielStreamer',
+    'stream_url_help' => 'Die URL des Twitch Streamers.',
+
+    /**
+     * Buttons
+     */
+    'dismiss_button' => 'Abbrechen',
+    'update_button' => 'Aktualisieren',
+
+    /**
+     * Form Validation
+     */
+    'form_validation_looks_good' => 'Sieht gut aus!',
+    'stream_url_validation_error' => 'Bitte gib eine gültige Twitch Stream URL an!',
+
+];

--- a/laravel/lang/en/views/administration/twitch.php
+++ b/laravel/lang/en/views/administration/twitch.php
@@ -1,0 +1,74 @@
+<?php
+
+return [
+
+    /**
+     * Twitch Headline
+     */
+    'twitch' => 'Twitch',
+
+    /**
+     * Accordion
+     */
+    'api_credentials_accordion_headline' => 'Twitch API Credentials',
+
+    'api_credentials_accordion_unconfigured' => 'Unconfigured',
+    'api_credentials_accordion_invalid_credentials' => 'Invalid Credentials',
+    'api_credentials_accordion_valid_credentials' => 'Valid Credentials',
+
+    'api_usage_information' => 'To be able to use this integration, you need to register this application as an application at Twitch, so that you get API credentials.',
+    'twitch_register_app_documentation' => 'Here you can find the detailed official documentation: <a href="https://dev.twitch.tv/docs/authentication/register-app">https://dev.twitch.tv/docs/authentication/register-app</a>',
+    'installation_instructions' => 'Quick instructions',
+    'step_login_or_create_twitch_account' => 'Login to your Twitch account or sign up for a new one, if you don\'t have any yet',
+    'step_open_twitch_dev_console' => 'Open <a href="https://dev.twitch.tv/console">https://dev.twitch.tv/console</a>',
+    'step_open_applications' => 'Click on <b>Applications</b>',
+    'step_open_register_app' => 'Click on <b>Register your app</b>',
+    'step_fill_out_the_form' => 'Fill out the form',
+    'step_fill_out_the_form_name' => '<b>Name</b>: <code>teamspeak-dynamic-banner</code> (just an example; use whatever name, which you want - it\'s only visible on this Twitch page)',
+    'step_fill_out_the_form_oauth_redirect_urls' => '<b>OAuth Redirect URLs</b>: <code>http://localhost</code> (not relevant, so simply set this for example)',
+    'step_fill_out_the_form_category' => '<b>Category</b>: <code>Website Integration</code>',
+    'step_open_new_app' => 'Click on <b>Manage</b> next to your new application',
+    'step_copy_and_insert_client_id' => 'Afterwards, you will see the <code>Client-ID</code> of your application. Insert this value into the <b>Client ID</b> field here.',
+    'step_copy_and_insert_client_secret' => 'Click on <b>New secret</b>. You will temporary see/get the <code>Client-Secret</code> of your application. Insert this value into the <b>Client Secret</b> field here.',
+    'step_submit_form' => 'Submit the form',
+
+    'api_client_id' => 'Client ID',
+    'api_client_id_placeholder' => 'e. g. 1ec8e09a145fc972b5eed9d1deb51631',
+    'api_client_id_help' => 'The client ID of your Twitch API credentials.',
+
+    'api_client_secret' => 'Client Secret',
+    'api_client_secret_placeholder' => 'e. g. ca733c04c302365cc782283ed5b7d39a',
+    'api_client_secret_help' => 'The client secret of your Twitch API credentials.',
+
+    /**
+     * Buttons
+     */
+    'save_button' => 'Save',
+    'delete_api_credentials_button' => 'Delete API credentials',
+    'add_streamer_button' => 'Add Twitch streamer',
+
+    /**
+     * Information Box
+     */
+    'no_permissions_to_edit_the_api_credentials' => 'You do not have permissions to view and change the API credentials. Please contact an admin.',
+    'no_streamer_added_info' => 'No Twitch streamer have been added yet.',
+    'no_twitch_api_credentials_are_configured' => 'This integration will only work, when you configure valid Twitch API credentials. This integration will currently neither pull any Twitch stream information, nor enable or disable your banner templates when configured.',
+
+    /**
+     * Datatable
+     */
+    'table_stream_status' => 'Status',
+    'table_stream_url' => 'Stream URL',
+    'table_last_modified' => 'Last Modified',
+
+    'table_stream_status_online' => 'Online',
+    'table_stream_status_offline' => 'Offline',
+
+    /**
+     * Form Validation
+     */
+    'form_validation_looks_good' => 'Looks good!',
+    'api_client_id_validation_error' => 'Please provide a valid client ID!',
+    'api_client_secret_validation_error' => 'Please provide a valid client secret!',
+
+];

--- a/laravel/lang/en/views/banner/configuration.php
+++ b/laravel/lang/en/views/banner/configuration.php
@@ -36,6 +36,7 @@ return [
      */
     'accordion_status_not_configured' => 'Unconfigured',
     'accordion_status_configured' => 'Configured',
+    'accordion_status_configured_but_ignored' => 'Ignored',
     'accordion_status_no_configurations' => 'No configurations',
     'accordion_status_has_configurations' => '{1} :count_configurations configuration|{2,*} :count_configurations configurations',
 
@@ -56,11 +57,17 @@ return [
     'disable_at_help' => 'Define an optional date and time, when this configuration should be automatically disabled. Leave it unset to not automatically disable it.',
 
     'time_based_de_activation_accordion_headline' => 'Time-Based Acivation/Deactivation',
+    'twitch_based_de_activation_no_twitch_api_credentials_are_configured' => 'This integration will only work, when you configure valid Twitch API credentials. This integration will currently neither pull any Twitch stream information, nor enable or disable your banner templates when configured.',
     'time_based_de_activation_use_case' => 'This function is for example useful when you want to show specific banner configurations only during a specific time window.',
     'time_based_de_activation_enable_at' => 'Enable at',
     'time_based_de_activation_enable_at_help' => 'Define an optional time, when this configuration should be automatically enabled. Leave it unset to not automatically enable it.',
     'time_based_de_activation_disable_at' => 'Disable at',
     'time_based_de_activation_disable_at_help' => 'Define an optional time, when this configuration should be automatically disabled. Leave it unset to not automatically disable it.',
+
+    'twitch_based_de_activation_accordion_headline' => 'Twitch-Based Acivation/Deactivation',
+    'twitch_based_de_activation_use_case' => 'This function is for example useful when you want to show specific banner configurations only when the respective Twitch streamer is online.',
+    'twitch_based_de_activation_twitch_streamer_id' => 'Twitch Streamer',
+    'twitch_based_de_activation_twitch_streamer_id_help' => 'Select an optional Twitch streamer to automatically enable and disable this banner template when the streamer is online or offline.',
 
     'text_configurations_accordion_headline' => 'Text Configurations',
 

--- a/laravel/lang/en/views/layouts/nav-main.php
+++ b/laravel/lang/en/views/layouts/nav-main.php
@@ -25,6 +25,7 @@ return [
     'administration_users' => 'Users',
     'administration_roles' => 'Roles',
     'administration_fonts' => 'Fonts',
+    'administration_twitch' => 'Twitch',
     'administration_systemstatus' => 'System Status',
     'administration_phpinfo' => 'PHP Info',
 

--- a/laravel/lang/en/views/modals/delete-feedback/modal-delete-twitch-api-credentials.php
+++ b/laravel/lang/en/views/modals/delete-feedback/modal-delete-twitch-api-credentials.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /**
+     * Modal Headline
+     */
+    'delete_twitch_api_credentials' => 'Delete Twitch API credentials',
+
+    /**
+     * Form
+     */
+    'are_you_sure_question' => 'Are you really sure, that you want to delete the Twitch API credentials from the system?',
+    'not_revertible_hint' => 'This action is not revertible.',
+
+    /**
+     * Buttons
+     */
+    'dismiss_button' => 'Abort',
+    'delete_button' => 'Delete',
+
+];

--- a/laravel/lang/en/views/modals/delete-feedback/modal-delete-twitch.php
+++ b/laravel/lang/en/views/modals/delete-feedback/modal-delete-twitch.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /**
+     * Modal Headline
+     */
+    'delete_twitch_streamer' => 'Delete twitch streamer',
+
+    /**
+     * Form
+     */
+    'are_you_sure_question' => 'Are you really sure, that you want to delete the Twitch streamer <a href=":stream_url" target="_blank">:stream_url</a>?',
+    'relation_deletion_hint' => 'This will also automatically remove the automatic enabling / disabling setting from all banner text configurations, which use this twitch streamer.',
+    'not_revertible_hint' => 'This action is not revertible.',
+
+    /**
+     * Buttons
+     */
+    'dismiss_button' => 'Abort',
+    'delete_button' => 'Delete',
+
+];

--- a/laravel/lang/en/views/modals/twitch/modal-add.php
+++ b/laravel/lang/en/views/modals/twitch/modal-add.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+
+    /**
+     * Modal Headline
+     */
+    'add_new_twitch_streamer' => 'Add new Twitch streamer',
+
+    /**
+     * Form
+     */
+    'stream_url' => 'Stream URL',
+    'stream_url_placeholder' => 'e. g. https://www.twitch.tv/ExampleStreamer',
+    'stream_url_help' => 'The URL of the Twitch streamer.',
+
+    /**
+     * Buttons
+     */
+    'dismiss_button' => 'Abort',
+    'add_button' => 'Add',
+
+    /**
+     * Form Validation
+     */
+    'form_validation_looks_good' => 'Looks good!',
+    'stream_url_validation_error' => 'Please provide a valid Twitch stream URL!',
+
+];

--- a/laravel/lang/en/views/modals/twitch/modal-edit.php
+++ b/laravel/lang/en/views/modals/twitch/modal-edit.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+
+    /**
+     * Modal Headline
+     */
+    'update_streamer' => 'Update Twitch streamer: <code>:stream_url</code>',
+
+    /**
+     * Form
+     */
+    'stream_url' => 'Stream URL',
+    'stream_url_placeholder' => 'e. g. https://www.twitch.tv/ExampleStreamer',
+    'stream_url_help' => 'The URL of the Twitch streamer.',
+
+    /**
+     * Buttons
+     */
+    'dismiss_button' => 'Abort',
+    'update_button' => 'Update',
+
+    /**
+     * Form Validation
+     */
+    'form_validation_looks_good' => 'Looks good!',
+    'stream_url_validation_error' => 'Please provide a valid Twitch stream URL!',
+
+];

--- a/laravel/resources/views/administration/twitch.blade.php
+++ b/laravel/resources/views/administration/twitch.blade.php
@@ -1,0 +1,242 @@
+@extends('layout')
+
+@section('site_title')
+    {{ __('views/administration/twitch.twitch') }}
+@endsection
+
+@section('dataTables_script')
+    <script>
+        $(document).ready( function () {
+            $('#fonts').DataTable({
+                "oLanguage": {
+                    "sLengthMenu": "_MENU_",
+                }
+            });
+        } );
+    </script>
+@endsection
+
+@section('content')
+<div class="container mt-3">
+    <div class="row">
+        <div class="col-lg-12">
+            <h1 class="fw-bold fs-3">{{ __('views/administration/twitch.twitch') }}</h1>
+        </div>
+    </div>
+    <hr>
+</div>
+
+<div class="container mt-3">
+    <div class="row">
+        <div class="col-lg-12">
+            <div class="accordion">
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="TwitchApiCredentialsHeading">
+                        <a class="accordion-button collapsed fw-bold bg-light text-decoration-none
+                            @if (is_null($twitch_api) or is_null($twitch_api->client_id) or is_null($twitch_api->client_secret) or Carbon\Carbon::now()->gt($twitch_api->expires_at)) collapsed @endif"
+                            type="button" data-bs-toggle="collapse" data-bs-target="#twitch_api_credentials" aria-expanded="false" aria-controls="twitch_api_credentials">
+                            <div class="col-lg-9">
+                                <span class="fs-5 fw-bold text-dark">{{ __('views/administration/twitch.api_credentials_accordion_headline') }}</span>
+                            </div>
+                            <div class="col-lg-2 me-5">
+                                @if (is_null($twitch_api) or is_null($twitch_api->client_id) or is_null($twitch_api->client_secret))
+                                    <span class="fs-5 fw-bold text-warning"><i class="fa fa-circle-exclamation"></i> {{ __('views/administration/twitch.api_credentials_accordion_unconfigured') }}</span>    
+                                @elseif (is_null($twitch_api->access_token) or Carbon\Carbon::now()->gt($twitch_api->expires_at))
+                                    <span class="fs-5 fw-bold text-danger"><i class="fa fa-circle-xmark"></i> {{ __('views/administration/twitch.api_credentials_accordion_invalid_credentials') }}</span>
+                                @else
+                                    <span class="fs-5 fw-bold text-success"><i class="fa fa-check-circle"></i> {{ __('views/administration/twitch.api_credentials_accordion_valid_credentials') }}</span>
+                                @endif
+                            </div>
+                        </a>
+                    </h2>
+                    <div id="twitch_api_credentials" class="accordion-collapse collapse" aria-labelledby="TwitchApiCredentialsHeading">
+                        <div class="accordion-body">
+                            @can('edit twitch api credentials')
+                                <div class="row">
+                                    <div class="col-lg-12">
+                                        <div class="alert alert-primary" role="alert">
+                                            <p>{{ __('views/administration/twitch.api_usage_information') }}</p>
+                                            <p>{!! __('views/administration/twitch.twitch_register_app_documentation') !!}</p>
+                                            <p>{{ __('views/administration/twitch.installation_instructions') }}:</p>
+                                            <ol>
+                                                <li>{{ __('views/administration/twitch.step_login_or_create_twitch_account') }}</li>
+                                                <li>{!! __('views/administration/twitch.step_open_twitch_dev_console') !!}</li>
+                                                <li>{!! __('views/administration/twitch.step_open_applications') !!}</li>
+                                                <li>{!! __('views/administration/twitch.step_open_register_app') !!}</li>
+                                                <li>{{ __('views/administration/twitch.step_fill_out_the_form') }}</li>
+                                                <ul>
+                                                    <li>{!! __('views/administration/twitch.step_fill_out_the_form_name') !!}</li>
+                                                    <li>{!! __('views/administration/twitch.step_fill_out_the_form_oauth_redirect_urls') !!}</li>
+                                                    <li>{!! __('views/administration/twitch.step_fill_out_the_form_category') !!}</li>
+                                                </ul>
+                                                <li>{!! __('views/administration/twitch.step_open_new_app') !!}</li>
+                                                <li>{!! __('views/administration/twitch.step_copy_and_insert_client_id') !!}</li>
+                                                <li>{!! __('views/administration/twitch.step_copy_and_insert_client_secret') !!}</li>
+                                                <li>{!! __('views/administration/twitch.step_submit_form') !!}</li>
+                                            </ol>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <form id="upsert-twitch-api-credentials" method="POST" action="{{ route('administration.twitch.update_api_credentials') }}" class="needs-validation" novalidate>
+                                    @method('patch')
+                                    @csrf
+                                    <div class="row">
+                                        <div class="col-lg-6">
+                                            <label for="validationApiClientId" class="form-label fw-bold">{{ __('views/administration/twitch.api_client_id') }}</label>
+                                            <input class="form-control" id="validationApiClientId" type="text" name="client_id"
+                                                value="{{ old('client_id', (isset($twitch_api->client_id)) ? $twitch_api->client_id : '') }}"
+                                                placeholder="{{ __('views/administration/twitch.api_client_id_placeholder') }}" aria-label="validationApiClientId"
+                                                aria-describedby="apiClientIdHelp validationApiClientIdFeedback" required>
+                                            <div id="apiClientIdHelp" class="form-text">{{ __('views/administration/twitch.api_client_id_help') }}</div>
+                                            <div class="valid-feedback">{{ __('views/administration/twitch.form_validation_looks_good') }}</div>
+                                            <div id="validationApiClientIdFeedback" class="invalid-feedback">{{ __('views/administration/twitch.api_client_id_validation_error') }}</div>
+                                        </div>
+
+                                        <div class="col-lg-6">
+                                            <label for="validationApiClientSecret" class="form-label fw-bold">{{ __('views/administration/twitch.api_client_secret') }}</label>
+                                            <input class="form-control" id="validationApiClientSecret" type="password" name="client_secret"
+                                                value="{{ old('client_secret', (isset($twitch_api->client_secret)) ? $twitch_api->client_secret : '') }}"
+                                                placeholder="{{ __('views/administration/twitch.api_client_secret_placeholder') }}" aria-label="validationApiClientSecret"
+                                                aria-describedby="apiClientSecretHelp validationApiClientSecretFeedback" required>
+                                            <div id="apiClientSecretHelp" class="form-text">{{ __('views/administration/twitch.api_client_secret_help') }}</div>
+                                            <div class="valid-feedback">{{ __('views/administration/twitch.form_validation_looks_good') }}</div>
+                                            <div id="validationApiClientSecretFeedback" class="invalid-feedback">{{ __('views/administration/twitch.api_client_secret_validation_error') }}</div>
+                                        </div>
+                                    </div>
+
+                                    <div class="row mb-2">
+                                        <div class="col-lg-3">
+                                            <button type="submit" class="form-control btn btn-primary">{{ __('views/administration/twitch.save_button') }}</button>
+                                        </div>
+                                        @can('delete twitch api credentials')
+                                            @if (! is_null($twitch_api))
+                                                <div class="col-lg-3">
+                                                    <button type="button" class="form-control btn btn-danger" data-bs-toggle="modal"
+                                                        data-bs-target="#deleteTwitchApiCredentials">
+                                                        {{ __('views/administration/twitch.delete_api_credentials_button') }}
+                                                    </button>
+                                                </div>
+                                            @endif
+                                        @endcan
+                                    </div>
+                                </form>
+                            @else
+                            <div class="row mt-2">
+                                <div class="col-lg-12">
+                                    <div class="alert alert-primary" role="alert">
+                                        {{ __('views/administration/twitch.no_permissions_to_edit_the_api_credentials') }}
+                                    </div>
+                                </div>
+                            </div>
+                            @endcan
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <hr>
+</div>
+
+@can('add twitch streamers')
+<div class="container">
+    <div class="row">
+        <div class="col-lg-3">
+            <button type="button" class="btn btn-primary btn-sm fw-bold" data-bs-toggle="modal" data-bs-target="#addTwitchStreamer">
+                {{ __('views/administration/twitch.add_streamer_button') }}
+            </button>
+        </div>
+    </div>
+    <hr>
+</div>
+@endcan
+<div class="container">
+    @include('inc.standard-alerts')
+
+    @if($twitch_streamer->count() == 0)
+    <div class="row">
+        <div class="col-lg-12">
+            <div class="row">
+                <div class="col-lg-12">
+                    <div class="alert alert-primary" role="alert">
+                        {{ __('views/administration/twitch.no_streamer_added_info') }}
+                        @can('add twitch streamers')
+                            <button class="btn btn-link p-0" data-bs-toggle="modal" data-bs-target="#addTwitchStreamer">{{ __('views/administration/twitch.add_streamer_button') }}</button>
+                        @endcan
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    @else
+    @if (is_null($twitch_api) or is_null($twitch_api->client_id) or is_null($twitch_api->client_secret))
+    <div class="row mt-2">
+        <div class="col-lg-12">
+            <div class="alert alert-warning">
+                <p>{{ __('views/administration/twitch.no_twitch_api_credentials_are_configured') }}</p>
+            </div>
+        </div>
+    </div>
+    @endif
+    <div class="row">
+        <div class="col-lg-12">
+            <table class="table table-striped" id="fonts">
+                <thead>
+                <tr>
+                    <th class="col-lg-1">{{ __('views/administration/twitch.table_stream_status') }}</th>
+                    <th class="col-lg-8">{{ __('views/administration/twitch.table_stream_url') }}</th>
+                    <th class="col-lg-2">{{ __('views/administration/twitch.table_last_modified') }}</th>
+                    <th class="col-lg-1"></th>
+                </tr>
+                </thead>
+                <tbody>
+                @foreach($twitch_streamer as $streamer)
+                <tr>
+                    <td>
+                        @if ($streamer->is_live)
+                        <span class="badge text-bg-success">{{ __('views/administration/twitch.table_stream_status_online') }}</span>
+                        @else
+                        <span class="badge text-bg-danger">{{ __('views/administration/twitch.table_stream_status_offline') }}</span>
+                        @endif
+                    </td>
+                    <td><a href="{{ $streamer->stream_url }}" target="_blank">{{ $streamer->stream_url }}</a></td>
+                    <td>{{ Carbon\Carbon::parse($streamer->updated_at)->setTimezone(Request::header('X-Timezone')) }}</td>
+                    <td>
+                        <div class="d-flex">
+                            @can('edit twitch streamers')
+                                <button class="btn btn-link px-0 me-2" type="button" data-bs-toggle="modal" data-bs-target="#editTwitchStreamer-{{$streamer->id}}"><i class="fa-solid fa-pencil text-primary fa-lg"></i></button>
+                            @endcan
+                            @can('delete twitch streamers')
+                                <button class="btn btn-link px-0 me-2" type="button" data-bs-toggle="modal" data-bs-target="#deleteTwitchStreamer-{{$streamer->id}}"><i class="fa-solid fa-trash text-danger fa-lg"></i></button>
+                            @endcan
+                        </div>
+                    </td>
+                </tr>
+                @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+    @endif
+</div>
+
+@can('delete twitch api credentials')
+    @include('modals.delete-feedback.modal-delete-twitch-api-credentials')
+@endcan
+
+@can('add twitch streamers')
+    @include('modals.twitch.modal-add')
+@endcan
+
+@foreach($twitch_streamer as $streamer)
+    @can('edit twitch streamers')
+        @include('modals.twitch.modal-edit', ['streamer' => $streamer])
+    @endcan
+
+    @can('delete twitch streamers')
+        @include('modals.delete-feedback.modal-delete-twitch', ['streamer' => $streamer])
+    @endcan
+@endforeach
+
+@endsection

--- a/laravel/resources/views/banner/configuration.blade.php
+++ b/laravel/resources/views/banner/configuration.blade.php
@@ -182,6 +182,51 @@
                         </div>
                     </div>
                     <div class="accordion-item">
+                        <h2 class="accordion-header" id="twitchDeActivationHeading">
+                            <a class="accordion-button collapsed text-decoration-none text-dark fw-bold bg-light" data-bs-toggle="collapse" data-bs-target="#twitchDeActivation" aria-expanded="false" aria-controls="twitchDeActivation">
+                                <div class="col-lg-9">
+                                    {{ __('views/banner/configuration.twitch_based_de_activation_accordion_headline') }}
+                                </div>
+                                <div class="col-lg-2 text-end">
+                                    @if (isset($banner_template) and !is_null($banner_template->twitch_streamer_id))
+                                        @if (is_null($twitch_api) or is_null($twitch_api->client_id) or is_null($twitch_api->client_secret))
+                                        <span class="badge text-bg-warning ms-2">{{ __('views/banner/configuration.accordion_status_configured_but_ignored') }}</span>
+                                        @else
+                                        <span class="badge text-bg-success ms-2">{{ __('views/banner/configuration.accordion_status_configured') }}</span>
+                                        @endif
+                                    @else
+                                        <span class="badge text-bg-warning ms-2">{{ __('views/banner/configuration.accordion_status_not_configured') }}</span>
+                                    @endif
+                                </div>
+                            </a>
+                        </h2>
+                        <div id="twitchDeActivation" class="accordion-collapse collapse" aria-labelledby="twitchDeActivation">
+                            <div class="accordion-body">
+                                @if (is_null($twitch_api) or is_null($twitch_api->client_id) or is_null($twitch_api->client_secret))
+                                <div class="row mt-2">
+                                    <div class="col-lg-12">
+                                        <div class="alert alert-warning">
+                                            <p>{{ __('views/banner/configuration.twitch_based_de_activation_no_twitch_api_credentials_are_configured') }}</p>
+                                        </div>
+                                    </div>
+                                </div>
+                                @endif
+
+                                <p class="mt-2">{{ __('views/banner/configuration.twitch_based_de_activation_use_case') }}</p>
+                                <label for="validationTwitchBasedDeActivation" class="form-label">{{ __('views/banner/configuration.twitch_based_de_activation_twitch_streamer_id') }}</label>
+                                <select class="form-control" id="validationTwitchBasedDeActivation" name="twitch_streamer_id" aria-label="validationTwitchBasedDeActivation">
+                                    <option value="">Disable</option>
+                                    @foreach ($twitch_streamer as $streamer)
+                                    <option value="{{ $streamer->id }}" @if ($banner_template->twitch_streamer_id == $streamer->id) selected @endif>{{ $streamer->stream_url }}</option>
+                                    @endforeach
+                                </select>
+                                <div class="valid-feedback">{{ __('views/banner/configuration.form_validation_looks_good') }}</div>
+                                <div class="invalid-feedback">{{ __('views/banner/configuration.twitch_streamer_id_validation_error') }}</div>
+                                <div class="form-text">{{ __('views/banner/configuration.twitch_based_de_activation_twitch_streamer_id_help') }}</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="accordion-item">
                         <h2 class="accordion-header" id="bannerConfigHeading">
                             <a class="accordion-button text-decoration-none text-dark fw-bold bg-light" data-bs-toggle="collapse" data-bs-target="#bannerConfig" aria-expanded="false" aria-controls="bannerConfig">
                                 <div class="col-lg-9">
@@ -234,8 +279,9 @@
 
 @include('inc.form-validation')
 
-@foreach($instance as $instanceVariableModal)
-    @include('modals.modal-variables', ['instanceVariableModal'=>$instanceVariableModal])
-@endforeach
+@include('modals.modal-variables', [
+        'twitch_streamer_variables' => $twitch_streamer_variables,
+        'instanceVariableModal' => $instance,
+    ])
 
 @endsection

--- a/laravel/resources/views/banners.blade.php
+++ b/laravel/resources/views/banners.blade.php
@@ -93,7 +93,6 @@
                             @can('edit banners')
                                 <button class="btn btn-link px-0 me-2" type="button" data-bs-toggle="modal" data-bs-target="#editBanner-{{$banner->id}}"><i class="fa-solid fa-pencil text-primary fa-lg"></i></button>
                             @endcan
-                                <button class="btn btn-link px-0 me-2" type="button" data-bs-toggle="modal" data-bs-target="#modalAvailableVariables-{{$banner->instance->id}}"><i class="fa-solid fa-square-root-variable text-primary fa-lg"></i></button>
                             @can('edit banners')
                                 <a href="{{ route('banner.templates', ['banner_id' => $banner->id]) }}" class="btn btn-link px-0 me-2"><i class="fa-solid fa-image text-primary fa-lg"></i></a>
                             @endcan
@@ -124,10 +123,6 @@
     @can('delete banners')
         @include('modals.delete-feedback.modal-delete-banner', ['bannerDeleteModal'=>$bannerModal])
     @endcan
-@endforeach
-
-@foreach($instance_list as $instanceVariableModal)
-    @include('modals.modal-variables', ['instanceVariableModal'=>$instanceVariableModal])
 @endforeach
 
 @endsection

--- a/laravel/resources/views/instances.blade.php
+++ b/laravel/resources/views/instances.blade.php
@@ -136,6 +136,7 @@
                                     <button type="submit" class="btn btn-link px-0 me-2"><i class="fa-solid fa-rotate-left text-warning fa-lg"></i></button>
                                 </form>
                             @endcan
+                            <button class="btn btn-link px-0 me-2" type="button" data-bs-toggle="modal" data-bs-target="#modalAvailableVariables-{{$instance->id}}"><i class="fa-solid fa-square-root-variable text-primary fa-lg"></i></button>
                             @can('edit instances')
                                 <button class="btn btn-link px-0 me-2" type="button" data-bs-toggle="modal" data-bs-target="#modalEditInstance-{{$instance->id}}"><i class="fa-solid fa-pencil text-primary fa-lg"></i></button>
                             @endcan
@@ -155,9 +156,12 @@
 @include('modals.instance.modal-add')
 
 @foreach($instances as $instanceModal)
+    @include('modals.modal-variables', ['instanceVariableModal' => $instanceModal])
+
     @can('edit instances')
         @include('modals.instance.modal-edit', ['instanceModal'=>$instanceModal,'channel_list'=>$channel_list])
     @endcan
+
     @can('delete instances')
         @include('modals.delete-feedback.modal-delete-instance', ['instanceDeleteModal'=>$instanceModal])
     @endcan

--- a/laravel/resources/views/layouts/nav-main.blade.php
+++ b/laravel/resources/views/layouts/nav-main.blade.php
@@ -67,7 +67,7 @@
             </ul>
         </div>
         <div class="collapse navbar-collapse justify-content-end text-bg-dark">
-            @canany(['view users', 'view roles','view fonts','view system status','view php info'])
+            @canany(['view users', 'view roles', 'view fonts', 'view twitch', 'view system status', 'view php info'])
                 <ul class="navbar-nav my-auto">
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle
@@ -84,6 +84,9 @@
                             @endcan
                             @can('view fonts')
                             <li><a class="dropdown-item {{ (Route::currentRouteName() == 'administration.fonts') ? 'active' : '' }}" href="{{ route('administration.fonts') }}">{{ __("views/layouts/nav-main.administration_fonts") }}</a></li>
+                            @endcan
+                            @can('view twitch')
+                            <li><a class="dropdown-item {{ (Route::currentRouteName() == 'administration.twitch') ? 'active' : '' }}" href="{{ route('administration.twitch') }}">{{ __("views/layouts/nav-main.administration_twitch") }}</a></li>
                             @endcan
                             @can('view system status')
                             <li><a class="dropdown-item {{ (Route::currentRouteName() == 'administration.systemstatus') ? 'active' : '' }}" href="{{ route('administration.systemstatus') }}">{{ __("views/layouts/nav-main.administration_systemstatus") }}</a></li>

--- a/laravel/resources/views/modals/delete-feedback/modal-delete-twitch-api-credentials.blade.php
+++ b/laravel/resources/views/modals/delete-feedback/modal-delete-twitch-api-credentials.blade.php
@@ -1,0 +1,22 @@
+<div class="modal fade" id="deleteTwitchApiCredentials" tabindex="-1" aria-labelledby="deleteTwitchApiCredentialsLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title fs-5 fw-bold" id="deleteTwitchApiCredentialsLabel">{{ __('views/modals/delete-feedback/modal-delete-twitch-api-credentials.delete_twitch_api_credentials') }}</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="m-0">{{ __('views/modals/delete-feedback/modal-delete-twitch-api-credentials.are_you_sure_question') }}</p>
+                <p class="fw-bold text-danger m-0">{{ __('views/modals/delete-feedback/modal-delete-twitch-api-credentials.not_revertible_hint') }}</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('views/modals/delete-feedback/modal-delete-twitch-api-credentials.dismiss_button') }}</button>
+                <form method="post" action="{{ route('administration.twitch.delete_api_credentials') }}">
+                    @method('delete')
+                    @csrf
+                    <button class="btn btn-danger" type="submit">{{ __('views/modals/delete-feedback/modal-delete-twitch-api-credentials.delete_button') }}</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/laravel/resources/views/modals/delete-feedback/modal-delete-twitch.blade.php
+++ b/laravel/resources/views/modals/delete-feedback/modal-delete-twitch.blade.php
@@ -1,0 +1,23 @@
+<div class="modal fade" id="deleteTwitchStreamer-{{$streamer->id}}" tabindex="-1" aria-labelledby="deleteTwitchStreamer-{{$streamer->id}}-Label" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title fs-5 fw-bold" id="deleteTwitchStreamer-{{$streamer->id}}-Label">{{ __('views/modals/delete-feedback/modal-delete-twitch.delete_twitch_streamer') }}</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="m-0">{!! __('views/modals/delete-feedback/modal-delete-twitch.are_you_sure_question', ['stream_url' => $streamer->stream_url]) !!}</p>
+                <p class="m-0">{{ __('views/modals/delete-feedback/modal-delete-twitch.relation_deletion_hint') }}</p>
+                <p class="fw-bold text-danger m-0">{{ __('views/modals/delete-feedback/modal-delete-twitch.not_revertible_hint') }}</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('views/modals/delete-feedback/modal-delete-twitch.dismiss_button') }}</button>
+                <form method="post" action="{{ route('administration.twitch.delete_streamer', ['twitch_streamer_id' => $streamer->id]) }}">
+                    @method('delete')
+                    @csrf
+                    <button class="btn btn-danger" type="submit">{{ __('views/modals/delete-feedback/modal-delete-twitch.delete_button') }}</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/laravel/resources/views/modals/modal-variables.blade.php
+++ b/laravel/resources/views/modals/modal-variables.blade.php
@@ -10,7 +10,7 @@
                     <div class="alert alert-warning" role="alert">
                         {{$instanceVariableModal->variables()['redis_connection_error']}}
                     </div>
-                @else
+                @endif
                 <div class="col-lg-12">
                     <table class="table" id="availableVariables">
                         <thead>
@@ -20,6 +20,15 @@
                         </tr>
                         </thead>
                         <tbody>
+                        @if (isset($twitch_streamer_variables))
+                            @foreach ($twitch_streamer_variables as $key => $value)
+                                <tr>
+                                    <td><code>%{{ $key }}%</code></td>
+                                    <td>{{ $value }}</td>
+                                </tr>
+                            @endforeach
+                        @endif
+
                         @foreach($instanceVariableModal->variables()['variables_and_values'] as $key => $value)
                             <tr>
                                 <td><code>%{{ $key }}%</code></td>
@@ -29,7 +38,6 @@
                         </tbody>
                     </table>
                 </div>
-                @endif
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('views/modals/modal-variables.dismiss_button') }}</button>

--- a/laravel/resources/views/modals/twitch/modal-add.blade.php
+++ b/laravel/resources/views/modals/twitch/modal-add.blade.php
@@ -1,0 +1,34 @@
+<div class="modal fade" id="addTwitchStreamer" tabindex="-1" aria-labelledby="addTwitchStreamerLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title fs-5 fw-bold" id="addTwitchStreamerLabel">{{ __('views/modals/twitch/modal-add.add_new_twitch_streamer') }}</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form method="POST" action="{{ route('administration.twitch.create_streamer') }}" class="row g-3 needs-validation" novalidate>
+                @csrf
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="mb-3">
+                                <label for="validationStreamUrl" class="form-label">{{ __('views/modals/twitch/modal-add.stream_url') }}</label>
+                                <input class="form-control" id="validationStreamUrl" type="url" pattern="https://www.twitch.tv/.*" name="stream_url" value="{{ old('stream_url') }}"
+                                    placeholder="{{ __('views/modals/twitch/modal-add.stream_url_placeholder') }}"
+                                    aria-describedby="validationStreamUrlHelp validationStreamUrlFeedback" required>
+                                <div id="validationStreamUrlHelp" class="form-text">{{ __('views/modals/twitch/modal-add.stream_url_help') }}</div>
+                                <div class="valid-feedback">{{ __('views/modals/twitch/modal-add.form_validation_looks_good') }}</div>
+                                <div id="validationStreamUrlFeedback" class="invalid-feedback">{{ __('views/modals/twitch/modal-add.stream_url_validation_error') }}</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('views/modals/twitch/modal-add.dismiss_button') }}</button>
+                        <button type="submit" class="btn btn-primary">{{ __('views/modals/twitch/modal-add.add_button') }}</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@include('inc.form-validation')

--- a/laravel/resources/views/modals/twitch/modal-edit.blade.php
+++ b/laravel/resources/views/modals/twitch/modal-edit.blade.php
@@ -1,0 +1,35 @@
+<div class="modal fade" id="editTwitchStreamer-{{$streamer->id}}" tabindex="-1" aria-labelledby="editTwitchStreamer-{{$streamer->id}}-Label" aria-hidden="true">
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title fs-5 fw-bold" id="editTwitchStreamer-{{$streamer->id}}-Label">{!! __('views/modals/twitch/modal-edit.update_streamer', ['stream_url' => $streamer->stream_url]) !!}</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form method="POST" action="{{ route('administration.twitch.update_streamer', ['twitch_streamer_id' => $streamer->id]) }}" class="row g-3 needs-validation">
+                @method('patch')
+                @csrf
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="mb-3">
+                            <label for="validationStreamUrl" class="form-label">{{ __('views/modals/twitch/modal-edit.stream_url') }}</label>
+                                <input class="form-control" id="validationStreamUrl" type="url" pattern="https://www.twitch.tv/.*" name="stream_url" value="{{ old('stream_url', $streamer->stream_url) }}"
+                                    placeholder="{{ __('views/modals/twitch/modal-edit.stream_url_placeholder') }}"
+                                    aria-describedby="validationStreamUrlHelp validationStreamUrlFeedback" required>
+                                <div id="validationStreamUrlHelp" class="form-text">{{ __('views/modals/twitch/modal-edit.stream_url_help') }}</div>
+                                <div class="valid-feedback">{{ __('views/modals/twitch/modal-edit.form_validation_looks_good') }}</div>
+                                <div id="validationStreamUrlFeedback" class="invalid-feedback">{{ __('views/modals/twitch/modal-edit.stream_url_validation_error') }}</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('views/modals/twitch/modal-edit.dismiss_button') }}</button>
+                        <button type="submit" class="btn btn-primary">{{ __('views/modals/twitch/modal-edit.update_button') }}</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@include('inc.form-validation')

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Administration\FontsController;
 use App\Http\Controllers\Administration\PhpInfoController;
 use App\Http\Controllers\Administration\RolesController;
 use App\Http\Controllers\Administration\SystemStatusController;
+use App\Http\Controllers\Administration\TwitchController;
 use App\Http\Controllers\Administration\UsersController;
 use App\Http\Controllers\BannerConfigurationController;
 use App\Http\Controllers\BannerController;
@@ -87,6 +88,13 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/administration/font/create', [FontsController::class, 'create'])->name('administration.font.create')->middleware('permission:add fonts');
     Route::patch('/administration/font/{font_id}/update', [FontsController::class, 'update'])->name('administration.font.update')->middleware('permission:edit fonts');
     Route::delete('/administration/font/{font_id}/delete', [FontsController::class, 'delete'])->name('administration.font.delete')->middleware('permission:delete fonts');
+
+    Route::get('/administration/twitch', [TwitchController::class, 'view'])->name('administration.twitch')->middleware('permission:view twitch');
+    Route::patch('/administration/twitch/update/api-credentials', [TwitchController::class, 'update_api_credentials'])->name('administration.twitch.update_api_credentials')->middleware('permission:edit twitch api credentials');
+    Route::delete('/administration/twitch/delete/api-credentials', [TwitchController::class, 'delete_api_credentials'])->name('administration.twitch.delete_api_credentials')->middleware('permission:delete twitch api credentials');
+    Route::post('/administration/twitch/create/streamer', [TwitchController::class, 'create_streamer'])->name('administration.twitch.create_streamer')->middleware('permission:add twitch streamers');
+    Route::patch('/administration/twitch/update/streamer/{twitch_streamer_id}', [TwitchController::class, 'update_streamer'])->name('administration.twitch.update_streamer')->middleware('permission:edit twitch streamers');
+    Route::delete('/administration/twitch/delete/streamer/{twitch_streamer_id}', [TwitchController::class, 'delete_streamer'])->name('administration.twitch.delete_streamer')->middleware('permission:delete twitch streamers');
 
     Route::get('/administration/systemstatus', [SystemStatusController::class, 'system_status'])->name('administration.systemstatus')->middleware('permission:view system status');
     Route::get('/administration/phpinfo', [PhpInfoController::class, 'php_info'])->name('administration.phpinfo')->middleware('permission:view php info');

--- a/laravel/tests/Feature/API/v1/BannerTest.php
+++ b/laravel/tests/Feature/API/v1/BannerTest.php
@@ -8,6 +8,8 @@ use App\Models\BannerTemplate;
 use App\Models\Font;
 use App\Models\Instance;
 use App\Models\Template;
+use App\Models\TwitchApi;
+use App\Models\TwitchStreamer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
@@ -109,6 +111,8 @@ class BannerTest extends TestCase
      */
     public function test_api_returns_an_image_with_respective_http_headers_when_everything_is_fine(): void
     {
+        TwitchApi::factory()->create();
+
         $banner_configuration = BannerConfiguration::factory()
             ->for(
                 $banner_template = BannerTemplate::factory()
@@ -116,6 +120,8 @@ class BannerTest extends TestCase
                         $this->banner
                     )->for(
                         Template::factory()->create()
+                    )->for(
+                        TwitchStreamer::factory()->create(), 'twitch_streamer'
                     )->create(['enabled' => true])
             )
             ->for(Font::factory()->create())

--- a/laravel/tests/Feature/Commands/Banners/TwitchBasedDisablingTest.php
+++ b/laravel/tests/Feature/Commands/Banners/TwitchBasedDisablingTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\Commands\Banners;
+
+use App\Models\Banner;
+use App\Models\BannerTemplate;
+use App\Models\Instance;
+use App\Models\Template;
+use App\Models\TwitchApi;
+use App\Models\TwitchStreamer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TwitchBasedDisablingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected TwitchStreamer $twitch_streamer;
+
+    protected BannerTemplate $banner_template;
+
+    /**
+     * Setup the test environment.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        TwitchApi::factory()->create();
+
+        $this->twitch_streamer = TwitchStreamer::factory()->create();
+
+        $this->banner_template = BannerTemplate::factory()
+            ->for(
+                Banner::factory()->for(
+                    Instance::factory()->create()
+                )->create()
+            )
+            ->for(Template::factory()->create())
+            ->create(['enabled' => true]);
+    }
+
+    /**
+     * Test that the command immediately exits when no Twitch API credentials are configured.
+     */
+    public function test_command_immediately_exits_when_no_twitch_api_credentials_are_configured(): void
+    {
+        TwitchApi::truncate();
+
+        $this->artisan('banners:twitch-based-disabling')
+            ->expectsOutput('No twitch API has been configured yet. Skipping.')
+            ->doesntExpectOutputToContain('Checking')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the banner template does not get disabled when no `twitch_streamer_id` has been defined.
+     */
+    public function test_banner_template_does_not_get_disabled_when_unconfigured(): void
+    {
+        $this->artisan('banners:twitch-based-disabling')
+            ->expectsOutput('Checking 0 banner templates...')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the banner template does not get disabled when the `twitch_streamer_id` has been defined, but the streamer is online.
+     */
+    public function test_banner_template_does_not_get_disabled_when_configured_but_the_streamer_is_online(): void
+    {
+        $this->banner_template->twitch_streamer_id = $this->twitch_streamer->id;
+        $this->banner_template->save();
+
+        $this->twitch_streamer->is_live = true;
+        $this->twitch_streamer->save();
+
+        $this->artisan('banners:twitch-based-disabling')
+            ->expectsOutput('The banner template with the ID '.$this->banner_template->id.' should NOT be disabled yet. Skipping.')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the command continues, when the respective banner template is already disabled.
+     */
+    public function test_command_continues_when_the_banner_template_is_already_disabled(): void
+    {
+        $this->banner_template->twitch_streamer_id = $this->twitch_streamer->id;
+        $this->banner_template->enabled = false;
+        $this->banner_template->save();
+
+        $this->artisan('banners:twitch-based-disabling')
+            ->expectsOutput('The banner template with the ID '.$this->banner_template->id.' is already disabled. Skipping.')
+            ->doesntExpectOutput('Successfully disabled the banner template with the ID '.$this->banner_template->id.'. See '.route('banner.template.configuration.edit', ['banner_template_id' => $this->banner_template->id]).' for details.')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the banner template gets disabled when the `twitch_streamer_id` has been defined and the streamer is offline.
+     */
+    public function test_banner_template_gets_disabled_when_configured_and_the_streamer_is_offline(): void
+    {
+        $this->banner_template->twitch_streamer_id = $this->twitch_streamer->id;
+        $this->banner_template->save();
+
+        $this->twitch_streamer->is_live = false;
+        $this->twitch_streamer->save();
+
+        $this->artisan('banners:twitch-based-disabling')
+            ->expectsOutput('Successfully disabled the banner template with the ID '.$this->banner_template->id.'. See '.route('banner.template.configuration.edit', ['banner_template_id' => $this->banner_template->id]).' for details.')
+            ->assertSuccessful();
+    }
+}

--- a/laravel/tests/Feature/Commands/Banners/TwitchBasedEnablingTest.php
+++ b/laravel/tests/Feature/Commands/Banners/TwitchBasedEnablingTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\Commands\Banners;
+
+use App\Models\Banner;
+use App\Models\BannerTemplate;
+use App\Models\Instance;
+use App\Models\Template;
+use App\Models\TwitchApi;
+use App\Models\TwitchStreamer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TwitchBasedEnablingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected TwitchStreamer $twitch_streamer;
+
+    protected BannerTemplate $banner_template;
+
+    /**
+     * Setup the test environment.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        TwitchApi::factory()->create();
+
+        $this->twitch_streamer = TwitchStreamer::factory()->create();
+
+        $this->banner_template = BannerTemplate::factory()
+            ->for(
+                Banner::factory()->for(
+                    Instance::factory()->create()
+                )->create()
+            )
+            ->for(Template::factory()->create())
+            ->create(['enabled' => false]);
+    }
+
+    /**
+     * Test that the command immediately exits when no Twitch API credentials are configured.
+     */
+    public function test_command_immediately_exits_when_no_twitch_api_credentials_are_configured(): void
+    {
+        TwitchApi::truncate();
+
+        $this->artisan('banners:twitch-based-enabling')
+            ->expectsOutput('No twitch API has been configured yet. Skipping.')
+            ->doesntExpectOutputToContain('Checking')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the banner template does not get enabled when no `twitch_streamer_id` has been defined.
+     */
+    public function test_banner_template_does_not_get_enabled_when_unconfigured(): void
+    {
+        $this->artisan('banners:twitch-based-enabling')
+            ->expectsOutput('Checking 0 banner templates...')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the banner template does not get enabled when the `twitch_streamer_id` has been defined, but the streamer is offline.
+     */
+    public function test_banner_template_does_not_get_enabled_when_configured_but_the_streamer_is_offline(): void
+    {
+        $this->banner_template->twitch_streamer_id = $this->twitch_streamer->id;
+        $this->banner_template->save();
+
+        $this->twitch_streamer->is_live = false;
+        $this->twitch_streamer->save();
+
+        $this->artisan('banners:twitch-based-enabling')
+            ->expectsOutput('The banner template with the ID '.$this->banner_template->id.' should NOT be enabled yet. Skipping.')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the command continues, when the respective banner template is already enabled.
+     */
+    public function test_command_continues_when_the_banner_template_is_already_enabled(): void
+    {
+        $this->banner_template->twitch_streamer_id = $this->twitch_streamer->id;
+        $this->banner_template->enabled = true;
+        $this->banner_template->save();
+
+        $this->artisan('banners:twitch-based-enabling')
+            ->expectsOutput('The banner template with the ID '.$this->banner_template->id.' is already enabled. Skipping.')
+            ->doesntExpectOutput('Successfully enabled the banner template with the ID '.$this->banner_template->id.'. See '.route('banner.template.configuration.edit', ['banner_template_id' => $this->banner_template->id]).' for details.')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the banner template gets enabled when the `twitch_streamer_id` has been defined and the streamer is online.
+     */
+    public function test_banner_template_gets_enabled_when_configured_and_the_streamer_is_online(): void
+    {
+        $this->banner_template->twitch_streamer_id = $this->twitch_streamer->id;
+        $this->banner_template->save();
+
+        $this->twitch_streamer->is_live = true;
+        $this->twitch_streamer->save();
+
+        $this->artisan('banners:twitch-based-enabling')
+            ->expectsOutput('Successfully enabled the banner template with the ID '.$this->banner_template->id.'. See '.route('banner.template.configuration.edit', ['banner_template_id' => $this->banner_template->id]).' for details.')
+            ->assertSuccessful();
+    }
+}

--- a/laravel/tests/Feature/Commands/Twitch/UpdateApiAccessTokenTest.php
+++ b/laravel/tests/Feature/Commands/Twitch/UpdateApiAccessTokenTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\Commands\Twitch;
+
+use App\Models\TwitchApi;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UpdateApiAccessTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected TwitchApi $twitch_api;
+
+    /**
+     * Setup the test environment.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->twitch_api = TwitchApi::factory()->create();
+    }
+
+    /**
+     * Test that the command immediately aborts, when no API credentials have been configured.
+     */
+    public function test_command_immediately_aborts_when_no_api_credentials_have_been_configured(): void
+    {
+        $this->twitch_api->delete();
+
+        $this->artisan('twitch:update-api-access-token')
+            ->expectsOutput('No twitch API has been configured yet. Skipping.')
+            ->doesntExpectOutput('Performing a Twitch API authentication...')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the command immediately aborts, when the existing access token is at least valid for 30 minutes.
+     */
+    public function test_command_immediately_aborts_when_the_existing_access_token_is_at_least_valid_for_30_minutes(): void
+    {
+        $this->twitch_api->expires_at = Carbon::now()->addHour();
+        $this->twitch_api->save();
+
+        $this->artisan('twitch:update-api-access-token')
+            ->expectsOutput('The existing access token is still valid for at least the next 30 minutes. Skipping.')
+            ->doesntExpectOutput('Performing a Twitch API authentication...')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the command aborts, when invalid API credentials have been provided.
+     */
+    public function test_command_aborts_when_invalid_api_credentials_have_been_provided(): void
+    {
+        $this->twitch_api->access_token = 'invalid_access_token';
+        $this->twitch_api->save();
+
+        $this->artisan('twitch:update-api-access-token')
+            ->expectsOutput('Performing a Twitch API authentication...')
+            ->expectsOutputToContain('The Twitch API authentication request failed due to the following error:')
+            ->assertSuccessful();
+    }
+}

--- a/laravel/tests/Feature/Commands/Twitch/UpdateStreamerInformationTest.php
+++ b/laravel/tests/Feature/Commands/Twitch/UpdateStreamerInformationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature\Commands\Twitch;
+
+use App\Models\TwitchApi;
+use App\Models\TwitchStreamer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UpdateStreamerInformationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected TwitchApi $twitch_api;
+
+    protected TwitchStreamer $twitch_streamer;
+
+    /**
+     * Setup the test environment.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->twitch_api = TwitchApi::factory()->create();
+
+        $this->twitch_streamer = TwitchStreamer::factory()->create();
+    }
+
+    /**
+     * Test that the command immediately aborts, when no API credentials have been configured.
+     */
+    public function test_command_immediately_aborts_when_no_api_credentials_have_been_configured(): void
+    {
+        $this->twitch_api->delete();
+
+        $this->artisan('twitch:update-streamer-information')
+            ->expectsOutput('No Twitch API credentials have been provided yet. Doing nothing.')
+            ->doesntExpectOutputToContain('Retrieving current Twitch stream information for')
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that the command aborts, when invalid API credentials have been provided.
+     */
+    public function test_command_aborts_when_invalid_api_credentials_have_been_provided(): void
+    {
+        $this->twitch_api->access_token = 'invalid_access_token';
+        $this->twitch_api->save();
+
+        $this->artisan('twitch:update-streamer-information')
+            ->expectsOutput('Retrieving current Twitch stream information for 1 streams...')
+            ->expectsOutputToContain('The Twitch API request failed due to the following error:')
+            ->assertSuccessful();
+    }
+}

--- a/laravel/tests/Feature/Controllers/Administration/TwitchTest.php
+++ b/laravel/tests/Feature/Controllers/Administration/TwitchTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Tests\Feature\Controllers\Administration;
+
+use App\Models\Localization;
+use App\Models\TwitchApi;
+use App\Models\TwitchStreamer;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TwitchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Localization $localization;
+
+    protected User $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Run the DatabaseSeeder
+        $this->seed();
+
+        $this->localization = Localization::factory()->create();
+
+        $this->user = User::factory()->for($this->localization)->create();
+        $this->user->syncRoles('Twitch Super Admin');
+    }
+
+    /**
+     * Test, that the user gets redirected to the login, when he is unauthenticated.
+     */
+    public function test_user_gets_redirected_to_login_when_unauthenticated(): void
+    {
+        $response = $this->get(route('administration.twitch'));
+        $response->assertStatus(302);
+        $response->assertRedirect(route('login'));
+    }
+
+    /**
+     * Test, that the user can access the page, when he is authenticated.
+     */
+    public function test_page_gets_displayed_when_authenticated(): void
+    {
+        $response = $this->actingAs($this->user)->get(route('administration.twitch'));
+        $response->assertStatus(200);
+        $response->assertViewIs('administration.twitch');
+    }
+
+    /**
+     * Test that upserting a the Twitch API credentials requires to match the request rules.
+     */
+    public function test_upserting_twitch_api_credentials_requires_to_match_the_request_rules(): void
+    {
+        $response = $this->actingAs($this->user)->patch(route('administration.twitch.update_api_credentials'), [
+            'client_secret' => 'some_client_secret',
+        ]);
+        $response->assertSessionHasErrors(['client_id']);
+
+        $response = $this->actingAs($this->user)->patch(route('administration.twitch.update_api_credentials'), [
+            'client_id' => 'some_client_id',
+        ]);
+        $response->assertSessionHasErrors(['client_secret']);
+
+        $response = $this->actingAs($this->user)->patch(route('administration.twitch.update_api_credentials'), [
+            'client_id' => 'some_client_id',
+            'client_secret' => 'some_client_secret',
+        ]);
+        $response->assertSessionHasNoErrors();
+    }
+
+    /**
+     * Test that upserting the Twitch API credentials with invalid credentials returns the view with an error.
+     */
+    public function test_upserting_the_twitch_api_credentials_with_invalid_credentials_returns_the_view_with_an_error(): void
+    {
+        $response = $this->actingAs($this->user)->patch(route('administration.twitch.update_api_credentials'), [
+            'client_id' => 'some_invalid_client_id',
+            'client_secret' => 'some_invalid_client_secret',
+        ]);
+        $response->assertRedirectToRoute('administration.twitch');
+        $response->assertSessionHas('error');
+    }
+
+    /**
+     * Test that deleting the Twitch API credentials returns the view with a success message.
+     */
+    public function test_deleting_the_twitch_api_credentials_returns_the_view_with_a_success_message(): void
+    {
+        TwitchApi::factory()->create();
+
+        $response = $this->actingAs($this->user)->delete(route('administration.twitch.delete_api_credentials'), []);
+        $response->assertRedirectToRoute('administration.twitch');
+        $response->assertSessionHas('success');
+    }
+
+    /**
+     * Test that adding a new Twitch streamer requires to match the request rules.
+     */
+    public function test_adding_a_new_twitch_streamer_requires_to_match_the_request_rules(): void
+    {
+        $response = $this->actingAs($this->user)->post(route('administration.twitch.create_streamer'), [
+            'stream_url' => 'https://www.github.com/some/url',
+        ]);
+        $response->assertSessionHasErrors(['stream_url']);
+
+        $response = $this->actingAs($this->user)->post(route('administration.twitch.create_streamer'), [
+            'stream_url' => 'https://www.twitch.tv/randomStream',
+        ]);
+        $response->assertSessionHasNoErrors();
+    }
+
+    /**
+     * Test that adding a new Twitch streamer successfully returns the view.
+     */
+    public function test_adding_a_new_twitch_streamer_successfully_returns_the_view(): void
+    {
+        $response = $this->actingAs($this->user)->post(route('administration.twitch.create_streamer'), [
+            'stream_url' => 'https://www.twitch.tv/randomStream',
+        ]);
+        $response->assertRedirectToRoute('administration.twitch');
+        $response->assertSessionHas('success');
+    }
+
+    /**
+     * Test that updating an existing user requires to match the request rules.
+     */
+    public function test_updating_an_existing_twitch_streamer_requires_to_match_the_request_rules(): void
+    {
+        $other_twitch_streamer = TwitchStreamer::factory()->create();
+
+        $response = $this->actingAs($this->user)->patch(route('administration.twitch.update_streamer', ['twitch_streamer_id' => $other_twitch_streamer->id]), [
+            'stream_url' => 'https://www.github.com/some/url',
+        ]);
+        $response->assertSessionHasErrors(['stream_url']);
+
+        $response = $this->actingAs($this->user)->patch(route('administration.twitch.update_streamer', ['twitch_streamer_id' => $other_twitch_streamer->id]), [
+            'stream_url' => 'https://www.twitch.tv/randomStream',
+        ]);
+        $response->assertSessionHasNoErrors();
+    }
+
+    /**
+     * Test that updating an existing Twitch streamer is working as expected.
+     */
+    public function test_updating_an_existing_twitch_streamer_is_working_as_expected(): void
+    {
+        $other_twitch_streamer = TwitchStreamer::factory()->create();
+
+        $response = $this->actingAs($this->user)->patch(route('administration.twitch.update_streamer', ['twitch_streamer_id' => $other_twitch_streamer->id]), [
+            'stream_url' => 'https://www.twitch.tv/randomStream',
+        ]);
+        $response->assertRedirectToRoute('administration.twitch');
+        $response->assertSessionHas('success');
+    }
+
+    /**
+     * Test that trying to delete a Twitch streamer ID, which exists, returns the respective view.
+     */
+    public function test_delete_twitch_streamer_returns_the_view_when_the_given_id_exists(): void
+    {
+        $other_twitch_streamer = TwitchStreamer::factory()->create();
+
+        $response = $this->actingAs($this->user)->delete(route('administration.twitch.delete_streamer', ['twitch_streamer_id' => $other_twitch_streamer->id]));
+        $response->assertRedirectToRoute('administration.twitch');
+        $response->assertSessionHas('success');
+    }
+}

--- a/laravel/tests/Unit/Models/TwitchApiTest.php
+++ b/laravel/tests/Unit/Models/TwitchApiTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\TwitchApi;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Crypt;
+use Tests\TestCase;
+
+class TwitchApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected TwitchApi $twitch_api;
+
+    /**
+     * Setup the test environment.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->twitch_api = TwitchApi::factory()->create();
+    }
+
+    /**
+     * Test that the model can be created.
+     */
+    public function test_model_can_be_created(): void
+    {
+        $this->assertModelExists($this->twitch_api);
+    }
+
+    /**
+     * Test that the model properly hides specific attributes in serializations.
+     */
+    public function test_model_properly_hides_specific_attributes_in_serializations(): void
+    {
+        $this->assertArrayHasKey('client_id', $this->twitch_api->toArray());
+
+        $this->assertArrayNotHasKey('client_secret', $this->twitch_api->toArray());
+        $this->assertArrayNotHasKey('access_token', $this->twitch_api->toArray());
+    }
+
+    /**
+     * Test that the model properly casts specific attributes.
+     */
+    public function test_model_properly_casts_specific_attributes(): void
+    {
+        $plain_secret = 'veryS$ecretStr1nG!';
+
+        // Excplitly encrypting the secret should fail as the `$casts` would otherwise encrypt it a
+        // second time and then we would save the incorrect secret. Thus, this test is expected to fail.
+        $this->twitch_api->client_secret = Crypt::encryptString($plain_secret);
+        $this->twitch_api->save();
+        $this->assertNotEquals($plain_secret, $this->twitch_api->client_secret);
+
+        // Laravel automatically decrypts the encrypted value from the database when it fetches it due to
+        // the `$casts` configuration, so there is no need to decrypt the value.
+        $this->twitch_api->client_secret = $plain_secret;
+        $this->twitch_api->save();
+        $this->expectException(DecryptException::class);
+        Crypt::decryptString($this->twitch_api->client_secret);
+
+        // Laravel should automatically store the secret encrypted in the database as we have defined it
+        // as `$casts`, so we can store the plaintext value in the model.
+        $this->twitch_api->client_secret = $plain_secret;
+        $this->twitch_api->save();
+        $this->assertEquals($plain_secret, $this->twitch_api->client_secret);
+
+        $plain_token = 'veryS$ecretT0k3N!';
+
+        // Excplitly encrypting the token should fail as the `$casts` would otherwise encrypt it a
+        // second time and then we would save the incorrect token. Thus, this test is expected to fail.
+        $this->twitch_api->access_token = Crypt::encryptString($plain_token);
+        $this->twitch_api->save();
+        $this->assertNotEquals($plain_token, $this->twitch_api->access_token);
+
+        // Laravel automatically decrypts the encrypted value from the database when it fetches it due to
+        // the `$casts` configuration, so there is no need to decrypt the value.
+        $this->twitch_api->access_token = $plain_token;
+        $this->twitch_api->save();
+        $this->expectException(DecryptException::class);
+        Crypt::decryptString($this->twitch_api->access_token);
+
+        // Laravel should automatically store the token encrypted in the database as we have defined it
+        // as `$casts`, so we can store the plaintext value in the model.
+        $this->twitch_api->access_token = $plain_token;
+        $this->twitch_api->save();
+        $this->assertEquals($plain_token, $this->twitch_api->access_token);
+    }
+}

--- a/laravel/tests/Unit/Models/TwitchStreamerTest.php
+++ b/laravel/tests/Unit/Models/TwitchStreamerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\TwitchStreamer;
+use Carbon\Carbon;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Crypt;
+use Tests\TestCase;
+
+class TwitchStreamerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected TwitchStreamer $twitch_streamer;
+
+    /**
+     * Setup the test environment.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->twitch_streamer = TwitchStreamer::factory()->create();
+    }
+
+    /**
+     * Test that the model can be created.
+     */
+    public function test_model_can_be_created(): void
+    {
+        $this->assertModelExists($this->twitch_streamer);
+    }
+
+    /**
+     * Test that the model properly casts specific attributes.
+     */
+    public function test_model_properly_casts_specific_attributes(): void
+    {
+        $this->assertIsBool($this->twitch_streamer->is_live);
+        $this->assertInstanceOf(Carbon::class, $this->twitch_streamer->started_at);
+    }
+}


### PR DESCRIPTION
This integration allows to dynamically enable and disable templates of a banner when a specific twitch streamer is currently streaming or not.

Additionally, it adds some new banner variables like current stream viewer counter and game title. Search for `TWITCH_STREAM` variables to see all available Twitch variables. :-)

Administration Twitch settings:

![image](https://github.com/Sebbo94BY/teamspeak-dynamic-banner/assets/5154682/28bb91a2-478b-491c-9cd5-025332ebea94)

Banner template configuration:

![image](https://github.com/Sebbo94BY/teamspeak-dynamic-banner/assets/5154682/9c8e1f3d-02a0-4df4-8945-d4aebb9ea012)


Todo:
- [x] Add config options to banner template configuration page, where a specific Twitch streamer can be selected / used
- [x] Implement function to automatically enable / disable the respective banner template, when the Twitch streamer is streaming or not
- [x] Add new permissions and roles
- [x] Add PHPUnit tests
- [x] Adjust existing PHPUnit tests, if necessary
- [x] Ensure, that removing a configured Twitch streamer disables the respective configuration

Closes #178