### PR TITLE
Fix latest tag command in docs

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -37,7 +37,7 @@ cd teamspeak-dynamic-banner
 Checkout the latest version:
 
 ```shell
-git checkout $(git tag | tail -1)
+git checkout $(git describe --tags "$(git rev-list --tags --max-count=1)")
 ```
 
 

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -33,7 +33,7 @@ git branch
 Checkout the latest version:
 
 ```shell
-git checkout $(git tag | tail -1)
+git checkout $(git describe --tags "$(git rev-list --tags --max-count=1)")
 ```
 
 Confirm, that you are on the respective new version (marked with a star in front of the line):


### PR DESCRIPTION
Since `git tag` doesn't properly sort the tags, the command needs to look a bit different to actually get the latest tag.

# Before

```shell
$ git tag | tail -1
0.9.0
```

# After

```shell
$ git describe --tags "$(git rev-list --tags --max-count=1)"
0.13.0
```